### PR TITLE
fix(web): complete remaining lint/type cleanup

### DIFF
--- a/apps/web/app/alerts/page.tsx
+++ b/apps/web/app/alerts/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { apiFetch } from "../../lib/api";
 import Badge from "../components/Badge";
 import DataQualityMini from "../components/DataQualityMini";
@@ -40,7 +40,7 @@ export default function AlertsPage() {
   }>({ severity: "all", acknowledged: "false", entity_type: "all" });
   const [loading, setLoading] = useState(true);
 
-  async function fetchAlerts() {
+  const fetchAlerts = useCallback(async () => {
     try {
       setLoading(true);
       const params = new URLSearchParams();
@@ -56,16 +56,16 @@ export default function AlertsPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [filter]);
 
-  async function fetchSummary() {
+  const fetchSummary = useCallback(async () => {
     try {
       const data = await apiFetch<AlertSummary>("/alerts/summary");
       setSummary(data);
     } catch (e) {
       console.error("Failed to fetch summary:", e);
     }
-  }
+  }, []);
 
   async function acknowledgeAlert(id: number) {
     try {
@@ -73,8 +73,8 @@ export default function AlertsPage() {
         method: "POST",
         body: JSON.stringify({ acknowledged_by: "user" }),
       });
-      fetchAlerts();
-      fetchSummary();
+      void fetchAlerts();
+      void fetchSummary();
     } catch (e) {
       console.error("Failed to acknowledge alert:", e);
     }
@@ -83,17 +83,17 @@ export default function AlertsPage() {
   async function checkNow() {
     try {
       await apiFetch("/alerts/check-now", { method: "POST" });
-      fetchAlerts();
-      fetchSummary();
+      void fetchAlerts();
+      void fetchSummary();
     } catch (e) {
       console.error("Failed to check alerts:", e);
     }
   }
 
   useEffect(() => {
-    fetchAlerts();
-    fetchSummary();
-  }, [filter]);
+    void fetchAlerts();
+    void fetchSummary();
+  }, [fetchAlerts, fetchSummary]);
 
   const severityBadge = (severity: string) => {
     const tone = severity === "critical" ? "bad" : severity === "warning" ? "warn" : "neutral";

--- a/apps/web/app/charts/BarChart.tsx
+++ b/apps/web/app/charts/BarChart.tsx
@@ -12,7 +12,7 @@ import {
 } from "recharts";
 
 interface BarChartProps {
-  data: any[];
+  data: Array<Record<string, string | number | null | undefined>>;
   xKey: string;
   yKey: string;
   title: string;

--- a/apps/web/app/charts/LineChart.tsx
+++ b/apps/web/app/charts/LineChart.tsx
@@ -12,7 +12,7 @@ import {
 } from "recharts";
 
 interface LineChartProps {
-  data: any[];
+  data: Array<Record<string, string | number | null | undefined>>;
   xKey: string;
   yKey: string;
   title: string;

--- a/apps/web/app/components/DataQualityMini.tsx
+++ b/apps/web/app/components/DataQualityMini.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { apiFetch } from "../../lib/api";
 import Badge from "./Badge";
 import { DataQualityFlag } from "../types";
+import { toErrorMessage } from "../utils/error";
 
 type Props = {
   title?: string;
@@ -16,7 +17,7 @@ export default function DataQualityMini({ title = "Data Quality", limit = 12 }: 
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  async function load() {
+  const load = useCallback(async () => {
     setLoading(true);
     setErr(null);
     try {
@@ -27,16 +28,16 @@ export default function DataQualityMini({ title = "Data Quality", limit = 12 }: 
       if (includeResolved) params.set("include_resolved", "true");
       const data = await apiFetch<DataQualityFlag[]>(`/data-quality/flags?${params.toString()}`);
       setFlags(data);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setLoading(false);
     }
-  }
+  }, [entityType, includeResolved, limit, severity]);
 
   useEffect(() => {
-    load();
-  }, [severity, entityType, includeResolved]);
+    void load();
+  }, [load]);
 
   const severityTone = (s: string) =>
     s === "critical" ? "bad" : s === "warning" ? "warn" : "neutral";
@@ -48,7 +49,7 @@ export default function DataQualityMini({ title = "Data Quality", limit = 12 }: 
           <div className="panelTitle">{title}</div>
           <div className="muted">Offene Data-Quality-Flags</div>
         </div>
-        <button className="btn" onClick={load} disabled={loading}>
+        <button className="btn" onClick={() => void load()} disabled={loading}>
           Refresh
         </button>
       </div>

--- a/apps/web/app/cooperatives/[id]/page.tsx
+++ b/apps/web/app/cooperatives/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 import Badge from "../../components/Badge";
 import { DataQualityFlag } from "../../types";
+import { toErrorMessage } from "../../utils/error";
 
 type Cooperative = {
   id: number;
@@ -19,13 +20,31 @@ type Cooperative = {
   deleted_at?: string | null;
 };
 
+type CooperativeFormState = {
+  name: string;
+  country: string;
+  region: string;
+  region_id: number | "";
+  website: string;
+  sca_score: number | "";
+  notes: string;
+};
+
 export default function CooperativeDetailsPage() {
   const params = useParams();
   const id = Number(params?.id);
   const router = useRouter();
 
   const [data, setData] = useState<Cooperative | null>(null);
-  const [form, setForm] = useState<Partial<Cooperative>>({});
+  const [form, setForm] = useState<CooperativeFormState>({
+    name: "",
+    country: "",
+    region: "",
+    region_id: "",
+    website: "",
+    sca_score: "",
+    notes: "",
+  });
   const [saving, setSaving] = useState(false);
   const [flags, setFlags] = useState<DataQualityFlag[]>([]);
   const [qualityBusy, setQualityBusy] = useState(false);
@@ -51,13 +70,13 @@ export default function CooperativeDetailsPage() {
           name: d.name,
           country: d.country ?? "",
           region: d.region ?? "",
-          region_id: d.region_id ?? undefined,
+          region_id: d.region_id ?? "",
           website: d.website ?? "",
-          sca_score: d.sca_score ?? undefined,
+          sca_score: d.sca_score ?? "",
           notes: d.notes ?? "",
         });
-      } catch (e: any) {
-        setErr(e?.message ?? String(e));
+      } catch (error: unknown) {
+        setErr(toErrorMessage(error));
       }
     })();
   }, [id]);
@@ -70,8 +89,8 @@ export default function CooperativeDetailsPage() {
         `/data-quality/flags?entity_type=cooperative&entity_id=${id}`,
       );
       setFlags(f);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setQualityBusy(false);
     }
@@ -85,8 +104,8 @@ export default function CooperativeDetailsPage() {
         `/data-quality/flags?entity_type=cooperative&entity_id=${id}`,
       );
       setFlags(f);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setQualityBusy(false);
     }
@@ -97,18 +116,14 @@ export default function CooperativeDetailsPage() {
     setErr(null);
     setSaving(true);
     try {
-      const payload: any = {
+      const payload: Partial<Cooperative> = {
         name: (form.name ?? "").toString(),
         country: (form.country ?? "").toString() || null,
         region: (form.region ?? "").toString() || null,
         region_id: form.region_id ? Number(form.region_id) : null,
         website: (form.website ?? "").toString() || null,
         sca_score:
-          form.sca_score === undefined ||
-          form.sca_score === null ||
-          form.sca_score === ("" as any)
-            ? null
-            : Number(form.sca_score),
+          form.sca_score === "" || form.sca_score === null ? null : Number(form.sca_score),
         notes: (form.notes ?? "").toString() || null,
       };
       const updated = await apiFetch<Cooperative>(`/cooperatives/${id}`, {
@@ -117,8 +132,8 @@ export default function CooperativeDetailsPage() {
       });
       setData(updated);
       setMsg("Gespeichert.");
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setSaving(false);
     }
@@ -131,8 +146,8 @@ export default function CooperativeDetailsPage() {
     try {
       await apiFetch(`/cooperatives/${id}`, { method: "DELETE" });
       router.push("/cooperatives");
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     }
   }
 
@@ -145,8 +160,8 @@ export default function CooperativeDetailsPage() {
       });
       setData(restored);
       setMsg("Wiederhergestellt.");
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     }
   }
 
@@ -209,7 +224,7 @@ export default function CooperativeDetailsPage() {
               <div className="label">Name</div>
               <input
                 className="input"
-                value={(form.name ?? "") as string}
+                value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
               />
             </label>
@@ -219,7 +234,7 @@ export default function CooperativeDetailsPage() {
                 <div className="label">Land</div>
                 <input
                   className="input"
-                  value={(form.country ?? "") as string}
+                  value={form.country}
                   onChange={(e) => setForm({ ...form, country: e.target.value })}
                 />
               </label>
@@ -227,7 +242,7 @@ export default function CooperativeDetailsPage() {
                 <div className="label">Region</div>
                 <input
                   className="input"
-                  value={(form.region ?? "") as string}
+                  value={form.region}
                   onChange={(e) => setForm({ ...form, region: e.target.value })}
                 />
               </label>
@@ -239,7 +254,7 @@ export default function CooperativeDetailsPage() {
                 className="input"
                 value={form.region_id ?? ""}
                 onChange={(e) =>
-                  setForm({ ...form, region_id: e.target.value ? Number(e.target.value) : null })
+                  setForm({ ...form, region_id: e.target.value ? Number(e.target.value) : "" })
                 }
               >
                 <option value="">-</option>
@@ -255,7 +270,7 @@ export default function CooperativeDetailsPage() {
               <div className="label">Website</div>
               <input
                 className="input"
-                value={(form.website ?? "") as string}
+                value={form.website}
                 onChange={(e) => setForm({ ...form, website: e.target.value })}
                 placeholder="https://"
               />
@@ -267,8 +282,13 @@ export default function CooperativeDetailsPage() {
                 className="input"
                 type="number"
                 step="0.1"
-                value={(form.sca_score ?? "") as any}
-                onChange={(e) => setForm({ ...form, sca_score: e.target.value as any })}
+                value={form.sca_score}
+                onChange={(e) =>
+                  setForm({
+                    ...form,
+                    sca_score: e.target.value === "" ? "" : Number(e.target.value),
+                  })
+                }
               />
             </label>
 
@@ -276,7 +296,7 @@ export default function CooperativeDetailsPage() {
               <div className="label">Notizen</div>
               <textarea
                 className="textarea"
-                value={(form.notes ?? "") as string}
+                value={form.notes}
                 onChange={(e) => setForm({ ...form, notes: e.target.value })}
                 rows={6}
               />

--- a/apps/web/app/cooperatives/page.tsx
+++ b/apps/web/app/cooperatives/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { apiFetch } from "../../lib/api";
 import Badge from "../components/Badge";
 import { DataQualityFlag } from "../types";
+import { toErrorMessage } from "../utils/error";
 
 type Coop = {
   id: number;
@@ -20,6 +21,13 @@ type Coop = {
 type CoopList = { items: Coop[]; total: number };
 
 type FlagSummary = { count: number; tone: "bad" | "warn" | "neutral" };
+type DqFilter = "all" | "any" | "none" | "critical" | "warning" | "info";
+
+const DQ_FILTER_VALUES: DqFilter[] = ["all", "any", "none", "critical", "warning", "info"];
+
+function parseDqFilter(value: string): DqFilter {
+  return DQ_FILTER_VALUES.includes(value as DqFilter) ? (value as DqFilter) : "all";
+}
 
 export default function CooperativesPage() {
   const [data, setData] = useState<CoopList | null>(null);
@@ -27,11 +35,11 @@ export default function CooperativesPage() {
   const [regionMap, setRegionMap] = useState<Record<number, string>>({});
   const [q, setQ] = useState("");
   const [showArchived, setShowArchived] = useState(false);
-  const [dqFilter, setDqFilter] = useState<"all" | "any" | "none" | "critical" | "warning" | "info">("all");
+  const [dqFilter, setDqFilter] = useState<DqFilter>("all");
   const [busyId, setBusyId] = useState<number | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
-  async function load() {
+  const load = useCallback(async () => {
     try {
       const [res, flags, regions] = await Promise.all([
         apiFetch<Coop[] | CoopList>(
@@ -68,14 +76,14 @@ export default function CooperativesPage() {
         map[region.id] = `${region.name} (${region.country})`;
       }
       setRegionMap(map);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     }
-  }
+  }, [showArchived]);
 
   useEffect(() => {
-    load();
-  }, [showArchived]);
+    void load();
+  }, [load]);
 
   async function archiveCoop(id: number) {
     if (!confirm("Kooperative archivieren?")) return;
@@ -83,8 +91,8 @@ export default function CooperativesPage() {
     try {
       await apiFetch(`/cooperatives/${id}`, { method: "DELETE" });
       await load();
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setBusyId(null);
     }
@@ -95,8 +103,8 @@ export default function CooperativesPage() {
     try {
       await apiFetch(`/cooperatives/${id}/restore`, { method: "POST" });
       await load();
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setBusyId(null);
     }
@@ -156,7 +164,7 @@ export default function CooperativesPage() {
           <select
             className="input"
             value={dqFilter}
-            onChange={(e) => setDqFilter(e.target.value as any)}
+            onChange={(e) => setDqFilter(parseDqFilter(e.target.value))}
             style={{ width: 160 }}
           >
             <option value="all">DQ: alle</option>

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import KpiCard from "../components/KpiCard";
 import Badge from "../components/Badge";
 import MarketPriceWidget from "../components/MarketPriceWidget";
 import AnomalyFeedWidget from "../components/AnomalyFeedWidget";
+import { toErrorMessage } from "../utils/error";
 
 type ApiStatus = { status: string };
 
@@ -20,6 +21,8 @@ type MarketPoint = {
 type MarketSnapshot = Record<string, MarketPoint | null>;
 
 type Paged<T> = { items: T[]; total: number };
+
+type InventoryRow = Record<string, unknown>;
 
 type NewsItem = {
   id: number;
@@ -73,8 +76,8 @@ export default function DashboardPage() {
         const [h, m, coops, roasters, n, r, ops] = await Promise.all([
           apiFetch<ApiStatus>("/health", { skipAuth: true }),
           apiFetch<MarketSnapshot>("/market/latest"),
-          apiFetch<Paged<any> | any[]>("/cooperatives?limit=1"),
-          apiFetch<Paged<any> | any[]>("/roasters?limit=1"),
+          apiFetch<Paged<InventoryRow> | InventoryRow[]>("/cooperatives?limit=1"),
+          apiFetch<Paged<InventoryRow> | InventoryRow[]>("/roasters?limit=1"),
           apiFetch<NewsItem[]>("/news?limit=6"),
           apiFetch<Report[]>("/reports?limit=6"),
           apiFetch<OpsOverview>("/ops/overview"),
@@ -88,9 +91,9 @@ export default function DashboardPage() {
         setNews(Array.isArray(n) ? n : []);
         setReports(Array.isArray(r) ? r : []);
         setOpsOverview(ops);
-      } catch (e: any) {
+      } catch (error: unknown) {
         if (!alive) return;
-        setErr(e?.message ?? String(e));
+        setErr(toErrorMessage(error));
       } finally {
         if (!alive) return;
         setLoading(false);

--- a/apps/web/app/deals/page.tsx
+++ b/apps/web/app/deals/page.tsx
@@ -4,8 +4,21 @@ import { useState } from "react";
 import Link from "next/link";
 import { apiFetch } from "../../lib/api";
 import { useDeals, useCalculateMargin } from "../hooks/useDeals";
-import { MarginCalcRequest } from "../types";
+import { Deal, MarginCalcRequest } from "../types";
 import PieChart from "../charts/PieChart";
+
+function readMetaString(meta: Deal["meta"], key: string): string | null {
+  if (!meta) return null;
+  const value = meta[key];
+  return typeof value === "string" ? value : null;
+}
+
+function formatOutputValue(value: unknown): string {
+  if (typeof value === "number") return value.toFixed(2);
+  if (typeof value === "string") return value;
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return "-";
+}
 
 export default function DealsDashboard() {
   const [showCalculator, setShowCalculator] = useState(false);
@@ -29,11 +42,11 @@ export default function DealsDashboard() {
   const [busyId, setBusyId] = useState<number | null>(null);
 
   const deals = dealsData?.items || [];
-  const activeDeals = deals.filter((d) => !(d as any).deleted_at);
+  const activeDeals = deals.filter((d) => !d.deleted_at);
 
   const stats = {
     total: activeDeals.length,
-    totalValue: activeDeals.reduce((sum, d) => sum + ((d as any).value_eur || 0), 0),
+    totalValue: activeDeals.reduce((sum, d) => sum + (d.value_eur || 0), 0),
     avgMargin: 15.5,
   };
 
@@ -121,7 +134,7 @@ export default function DealsDashboard() {
         </div>
         <div className="panel card">
           <div className="cardLabel">Aktive Deals</div>
-          <div className="cardValue">{activeDeals.filter((d) => (d as any).status !== "closed").length}</div>
+          <div className="cardValue">{activeDeals.filter((d) => d.status !== "closed").length}</div>
           <div className="cardHint">In Bearbeitung</div>
         </div>
       </div>
@@ -258,7 +271,7 @@ export default function DealsDashboard() {
                             {key.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())}
                           </span>
                           <span style={{ fontWeight: "700" }}>
-                            {typeof value === "number" ? value.toFixed(2) : value}
+                            {formatOutputValue(value)}
                           </span>
                         </div>
                       ))}
@@ -309,38 +322,40 @@ export default function DealsDashboard() {
                 </tr>
               </thead>
               <tbody>
-                {deals.map((lot) => (
-                  <tr key={lot.id}>
-                    <td style={{ fontWeight: "600" }}>{(lot as any).reference || `LOT-${lot.id}`}</td>
-                    <td>{(lot as any).origin || "-"}</td>
-                    <td>{(lot as any).variety || "-"}</td>
-                    <td>{(lot as any).process || "-"}</td>
-                    <td>{(lot as any).grade || "-"}</td>
-                    <td>{(lot as any).weight_kg?.toLocaleString() || "-"}</td>
+                {deals.map((deal) => (
+                  <tr key={deal.id}>
+                    <td style={{ fontWeight: "600" }}>
+                      {readMetaString(deal.meta, "reference") || `LOT-${deal.id}`}
+                    </td>
+                    <td>{deal.origin_region || deal.origin_country || "-"}</td>
+                    <td>{deal.variety || "-"}</td>
+                    <td>{deal.process_method || "-"}</td>
+                    <td>{deal.quality_grade || "-"}</td>
+                    <td>{deal.weight_kg?.toLocaleString() || "-"}</td>
                     <td>
-                      {(lot as any).cupping_score ? (
-                        <span className="badge badgeOk">{(lot as any).cupping_score}</span>
+                      {deal.cupping_score ? (
+                        <span className="badge badgeOk">{deal.cupping_score}</span>
                       ) : (
                         "-"
                       )}
                     </td>
                     <td>
-                      {(lot as any).deleted_at ? (
+                      {deal.deleted_at ? (
                         <span className="badge badgeWarn">archiviert</span>
                       ) : (
-                        <span className="badge">{(lot as any).status || "active"}</span>
+                        <span className="badge">{deal.status || "active"}</span>
                       )}
                     </td>
                     <td>
-                      <Link href={`/lots/${lot.id}`} className="link">
+                      <Link href={`/lots/${deal.id}`} className="link">
                         Ansehen -
                       </Link>
-                      {(lot as any).deleted_at ? (
+                      {deal.deleted_at ? (
                         <button
                           className="btn"
                           style={{ marginLeft: 8 }}
-                          onClick={() => restoreLot(lot.id)}
-                          disabled={busyId === lot.id}
+                          onClick={() => restoreLot(deal.id)}
+                          disabled={busyId === deal.id}
                         >
                           Restore
                         </button>
@@ -348,8 +363,8 @@ export default function DealsDashboard() {
                         <button
                           className="btn"
                           style={{ marginLeft: 8 }}
-                          onClick={() => archiveLot(lot.id)}
-                          disabled={busyId === lot.id}
+                          onClick={() => archiveLot(deal.id)}
+                          disabled={busyId === deal.id}
                         >
                           Archivieren
                         </button>

--- a/apps/web/app/dedup/page.tsx
+++ b/apps/web/app/dedup/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { apiFetch } from "../../lib/api";
 import Badge from "../components/Badge";
+import { toErrorMessage } from "../utils/error";
+
+type EntityType = "cooperative" | "roaster";
 
 type DedupPair = {
   a_id: number;
@@ -16,18 +19,22 @@ type DedupPair = {
 type MergeHistory = {
   entity_id: number;
   created_at: string;
-  payload: any;
+  payload: unknown;
 };
 
+function parseEntityType(value: string): EntityType {
+  return value === "roaster" ? "roaster" : "cooperative";
+}
+
 export default function DedupPage() {
-  const [entityType, setEntityType] = useState<"cooperative" | "roaster">("cooperative");
+  const [entityType, setEntityType] = useState<EntityType>("cooperative");
   const [suggestions, setSuggestions] = useState<DedupPair[]>([]);
   const [history, setHistory] = useState<MergeHistory[]>([]);
   const [loading, setLoading] = useState(false);
   const [threshold, setThreshold] = useState(90);
   const [selectedPair, setSelectedPair] = useState<DedupPair | null>(null);
 
-  async function fetchSuggestions() {
+  const fetchSuggestions = useCallback(async () => {
     try {
       setLoading(true);
       const data = await apiFetch<DedupPair[]>(
@@ -39,9 +46,9 @@ export default function DedupPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [entityType, threshold]);
 
-  async function fetchHistory() {
+  const fetchHistory = useCallback(async () => {
     try {
       const data = await apiFetch<MergeHistory[]>(
         `/dedup/history?entity_type=${entityType}&limit=50`,
@@ -50,7 +57,7 @@ export default function DedupPage() {
     } catch (e) {
       console.error("Failed to fetch history:", e);
     }
-  }
+  }, [entityType]);
 
   async function mergePair(keepId: number, mergeId: number) {
     try {
@@ -66,15 +73,15 @@ export default function DedupPage() {
       setSelectedPair(null);
       fetchSuggestions();
       fetchHistory();
-    } catch (e: any) {
-      alert(`Fehler beim Zusammenfuehren: ${e?.message || e}`);
+    } catch (error: unknown) {
+      alert(`Fehler beim Zusammenfuehren: ${toErrorMessage(error)}`);
     }
   }
 
   useEffect(() => {
     fetchSuggestions();
     fetchHistory();
-  }, [entityType]);
+  }, [fetchHistory, fetchSuggestions]);
 
   const scoreColor = (score: number) => {
     if (score >= 95) return "bad";
@@ -96,7 +103,11 @@ export default function DedupPage() {
         <div className="row gap" style={{ flexWrap: "wrap" }}>
           <div>
             <div className="label">Entitaetstyp</div>
-            <select className="input" value={entityType} onChange={(e) => setEntityType(e.target.value as any)}>
+            <select
+              className="input"
+              value={entityType}
+              onChange={(e) => setEntityType(parseEntityType(e.target.value))}
+            >
               <option value="cooperative">Kooperativen</option>
               <option value="roaster">Roestereien</option>
             </select>

--- a/apps/web/app/hooks/usePeruRegions.ts
+++ b/apps/web/app/hooks/usePeruRegions.ts
@@ -8,6 +8,30 @@ import {
   RegionIntelligence,
 } from "../types";
 
+function normalizeCertifications(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => String(v).trim())
+      .filter((v) => v.length > 0);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0);
+  }
+  return [];
+}
+
+type RawCooperative = Omit<Cooperative, "certifications"> & { certifications?: unknown };
+
+function normalizeCooperative(raw: RawCooperative): Cooperative {
+  return {
+    ...raw,
+    certifications: normalizeCertifications(raw.certifications),
+  };
+}
+
 // Fetch Peru Regions
 export function usePeruRegions() {
   return useQuery({
@@ -52,15 +76,19 @@ export function useCooperatives(filters: Partial<CooperativeFilters> & { limit?:
     queryKey: ["cooperatives", filters],
     queryFn: async () => {
       const qs = params.toString();
-      const response = await apiFetch<Cooperative[] | Paged<Cooperative>>(
+      const response = await apiFetch<RawCooperative[] | Paged<RawCooperative>>(
         `/cooperatives${qs ? `?${qs}` : ""}`,
       );
       // Backend returns flat list, but we need Paged format
       // Check if response is already in Paged format
       if (Array.isArray(response)) {
-        return { items: response, total: response.length } as Paged<Cooperative>;
+        const items = response.map(normalizeCooperative);
+        return { items, total: items.length } as Paged<Cooperative>;
       }
-      return response;
+      return {
+        ...response,
+        items: (response.items || []).map(normalizeCooperative),
+      };
     },
   });
 }

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { apiFetch, setToken, Token } from "../../lib/api";
 import { useRouter } from "next/navigation";
+import { toErrorMessage } from "../utils/error";
 
 export default function LoginPage() {
   // Must be a valid email; avoid .local/.test (EmailStr rejects these).
@@ -21,8 +22,8 @@ export default function LoginPage() {
       });
       setToken(t.access_token);
       router.push("/dashboard");
-    } catch (err: any) {
-      setError(err.message || "Login failed");
+    } catch (error: unknown) {
+      setError(toErrorMessage(error) || "Login failed");
     }
   }
 

--- a/apps/web/app/lots/[id]/page.tsx
+++ b/apps/web/app/lots/[id]/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
+import { JsonObject } from "../../types";
+import { toErrorMessage } from "../../utils/error";
 
 type Lot = {
   id: number;
@@ -23,8 +25,41 @@ type MarginRun = {
   lot_id: number;
   profile: string;
   computed_at: string;
-  inputs: any;
-  outputs: any;
+  inputs: JsonObject;
+  outputs: JsonObject;
+};
+
+type CalcState = {
+  purchase_price_per_kg: string;
+  purchase_currency: string;
+  landed_costs_per_kg: string;
+  roast_and_pack_costs_per_kg: string;
+  yield_factor: string;
+  selling_price_per_kg: string;
+  selling_currency: string;
+  fx_usd_to_eur: string;
+};
+
+type MarginRunPayload = {
+  purchase_price_per_kg: number;
+  purchase_currency: string;
+  landed_costs_per_kg: number;
+  roast_and_pack_costs_per_kg: number;
+  yield_factor: number;
+  selling_price_per_kg: number;
+  selling_currency: string;
+  fx_usd_to_eur?: number;
+};
+
+const INITIAL_CALC: CalcState = {
+  purchase_price_per_kg: "",
+  purchase_currency: "USD",
+  landed_costs_per_kg: "0.0",
+  roast_and_pack_costs_per_kg: "0.0",
+  yield_factor: "0.84",
+  selling_price_per_kg: "",
+  selling_currency: "EUR",
+  fx_usd_to_eur: "",
 };
 
 export default function LotDetailPage() {
@@ -37,44 +72,38 @@ export default function LotDetailPage() {
   const [busy, setBusy] = useState(false);
 
   const [profile, setProfile] = useState("conservative");
-  const [calc, setCalc] = useState<any>({
-    purchase_price_per_kg: "",
-    purchase_currency: "USD",
-    landed_costs_per_kg: "0.0",
-    roast_and_pack_costs_per_kg: "0.0",
-    yield_factor: "0.84",
-    selling_price_per_kg: "",
-    selling_currency: "EUR",
-    fx_usd_to_eur: "",
-  });
+  const [calc, setCalc] = useState<CalcState>(INITIAL_CALC);
 
-  async function loadAll() {
+  const loadAll = useCallback(async () => {
     setErr(null);
     try {
       const l = await apiFetch<Lot>(`/lots/${id}?include_deleted=true`);
       setLot(l);
-      setCalc((prev: any) => ({
+      setCalc((prev) => ({
         ...prev,
-        purchase_price_per_kg: l.price_per_kg ?? prev.purchase_price_per_kg,
+        purchase_price_per_kg:
+          l.price_per_kg !== null && l.price_per_kg !== undefined
+            ? String(l.price_per_kg)
+            : prev.purchase_price_per_kg,
         purchase_currency: l.currency || prev.purchase_currency,
       }));
       const r = await apiFetch<MarginRun[]>(`/margins/lots/${id}/runs?limit=50`);
       setRuns(r);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     }
-  }
+  }, [id]);
 
   useEffect(() => {
     if (!id) return;
     loadAll();
-  }, [id]);
+  }, [id, loadAll]);
 
   async function computeAndStore() {
     setBusy(true);
     setErr(null);
     try {
-      const payload: any = {
+      const payload: MarginRunPayload = {
         purchase_price_per_kg: Number(calc.purchase_price_per_kg),
         purchase_currency: String(calc.purchase_currency || "USD"),
         landed_costs_per_kg: Number(calc.landed_costs_per_kg || 0),
@@ -91,8 +120,8 @@ export default function LotDetailPage() {
       );
       const r = await apiFetch<MarginRun[]>(`/margins/lots/${id}/runs?limit=50`);
       setRuns(r);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setBusy(false);
     }
@@ -105,8 +134,8 @@ export default function LotDetailPage() {
       await apiFetch(`/lots/${id}`, { method: "DELETE" });
       const l = await apiFetch<Lot>(`/lots/${id}?include_deleted=true`);
       setLot(l);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     }
   }
 
@@ -115,8 +144,8 @@ export default function LotDetailPage() {
     try {
       const l = await apiFetch<Lot>(`/lots/${id}/restore`, { method: "POST" });
       setLot(l);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     }
   }
 
@@ -255,14 +284,20 @@ export default function LotDetailPage() {
           ) : (
             <ul>
               {runs.map((r) => {
+                const grossMarginPerKg = r.outputs.gross_margin_per_kg;
                 const gmKg =
-                  typeof r.outputs?.gross_margin_per_kg === "number"
-                    ? r.outputs.gross_margin_per_kg.toFixed(2)
-                    : r.outputs?.gross_margin_per_kg ?? "-";
+                  typeof grossMarginPerKg === "number"
+                    ? grossMarginPerKg.toFixed(2)
+                    : typeof grossMarginPerKg === "string"
+                      ? grossMarginPerKg
+                      : "-";
+                const grossMarginPct = r.outputs.gross_margin_pct;
                 const gmPct =
-                  typeof r.outputs?.gross_margin_pct === "number"
-                    ? r.outputs.gross_margin_pct.toFixed(1)
-                    : r.outputs?.gross_margin_pct ?? "-";
+                  typeof grossMarginPct === "number"
+                    ? grossMarginPct.toFixed(1)
+                    : typeof grossMarginPct === "string"
+                      ? grossMarginPct
+                      : "-";
                 return (
                   <li key={r.id} style={{ marginBottom: 10 }}>
                     <div>

--- a/apps/web/app/lots/page.tsx
+++ b/apps/web/app/lots/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { apiFetch } from "../../lib/api";
+import { toErrorMessage } from "../utils/error";
 
 type Lot = {
   id: number;
@@ -17,31 +18,56 @@ type Lot = {
   deleted_at: string | null;
 };
 
+type LotFormState = {
+  cooperative_id: string;
+  name: string;
+  crop_year: string;
+  incoterm: string;
+  price_per_kg: string;
+  currency: string;
+  weight_kg: string;
+  expected_cupping_score: string;
+};
+
+type CreateLotPayload = {
+  cooperative_id: number;
+  name: string;
+  incoterm: string | null;
+  currency: string | null;
+  crop_year?: number;
+  price_per_kg?: number;
+  weight_kg?: number;
+  expected_cupping_score?: number;
+};
+
+const INITIAL_FORM: LotFormState = {
+  cooperative_id: "",
+  name: "",
+  crop_year: "",
+  incoterm: "FOB",
+  price_per_kg: "",
+  currency: "USD",
+  weight_kg: "",
+  expected_cupping_score: "",
+};
+
 export default function LotsPage() {
   const [lots, setLots] = useState<Lot[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
   const [busyId, setBusyId] = useState<number | null>(null);
-  const [form, setForm] = useState<any>({
-    cooperative_id: "",
-    name: "",
-    crop_year: "",
-    incoterm: "FOB",
-    price_per_kg: "",
-    currency: "USD",
-    weight_kg: "",
-    expected_cupping_score: "",
-  });
+  const [form, setForm] = useState<LotFormState>(INITIAL_FORM);
 
-  const load = () =>
-    apiFetch<Lot[]>(`/lots?limit=200&include_deleted=${showArchived ? "true" : "false"}`)
+  const load = useCallback(() => {
+    return apiFetch<Lot[]>(`/lots?limit=200&include_deleted=${showArchived ? "true" : "false"}`)
       .then(setLots)
-      .catch((e) => setErr(e?.message ?? String(e)));
+      .catch((error: unknown) => setErr(toErrorMessage(error)));
+  }, [showArchived]);
 
   useEffect(() => {
     load();
-  }, [showArchived]);
+  }, [load]);
 
   async function archiveLot(id: number) {
     if (!confirm("Lot archivieren?")) return;
@@ -49,8 +75,8 @@ export default function LotsPage() {
     try {
       await apiFetch(`/lots/${id}`, { method: "DELETE" });
       load();
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setBusyId(null);
     }
@@ -61,8 +87,8 @@ export default function LotsPage() {
     try {
       await apiFetch(`/lots/${id}/restore`, { method: "POST" });
       load();
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setBusyId(null);
     }
@@ -72,7 +98,7 @@ export default function LotsPage() {
     setErr(null);
     setCreating(true);
     try {
-      const payload: any = {
+      const payload: CreateLotPayload = {
         cooperative_id: Number(form.cooperative_id),
         name: String(form.name || "").trim(),
         incoterm: form.incoterm || null,
@@ -88,19 +114,10 @@ export default function LotsPage() {
         payload.expected_cupping_score = Number(form.expected_cupping_score);
 
       await apiFetch<Lot>("/lots", { method: "POST", body: JSON.stringify(payload) });
-      setForm({
-        cooperative_id: "",
-        name: "",
-        crop_year: "",
-        incoterm: "FOB",
-        price_per_kg: "",
-        currency: "USD",
-        weight_kg: "",
-        expected_cupping_score: "",
-      });
+      setForm(INITIAL_FORM);
       load();
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setCreating(false);
     }

--- a/apps/web/app/ml/page.tsx
+++ b/apps/web/app/ml/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "../../lib/api";
 import Badge from "../components/Badge";
+import { toErrorMessage } from "../utils/error";
 
 type MLModel = {
   id: number;
@@ -11,7 +12,7 @@ type MLModel = {
   algorithm: string | null;
   model_version: string;
   training_date: string;
-  performance_metrics: any;
+  performance_metrics: Record<string, unknown> | null;
   training_data_count: number;
   status: string;
 };
@@ -80,8 +81,8 @@ export default function MLPage() {
       await apiFetch(`/ml/train/${modelType}`, { method: "POST" });
       alert(`Modelltraining fuer ${modelType} gestartet!`);
       fetchModels();
-    } catch (e: any) {
-      alert(`Fehler beim Training: ${e?.message || e}`);
+    } catch (error: unknown) {
+      alert(`Fehler beim Training: ${toErrorMessage(error)}`);
     } finally {
       setTrainingModel(null);
     }

--- a/apps/web/app/news/page.tsx
+++ b/apps/web/app/news/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { apiFetch } from "../../lib/api";
 import Badge from "../components/Badge";
 import DataQualityMini from "../components/DataQualityMini";
+import { toErrorMessage } from "../utils/error";
 
 type NewsItem = {
   id: number;
@@ -24,7 +25,7 @@ export default function NewsPage() {
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
-  async function load() {
+  const load = useCallback(async () => {
     setLoading(true);
     setErr(null);
     try {
@@ -32,16 +33,16 @@ export default function NewsPage() {
         `/news?topic=${encodeURIComponent(topic)}&days=${days}&limit=60`,
       );
       setItems(d);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setLoading(false);
     }
-  }
+  }, [days, topic]);
 
   useEffect(() => {
     load();
-  }, []);
+  }, [load]);
 
   const sorted = useMemo(() => {
     const copy = [...items];
@@ -54,7 +55,12 @@ export default function NewsPage() {
     setMsg(null);
     setErr(null);
     try {
-      const r = await apiFetch<{ status: string; created: number; updated: number; errors: any[] }>(
+      const r = await apiFetch<{
+        status: string;
+        created: number;
+        updated: number;
+        errors: unknown[];
+      }>(
         `/news/refresh?topic=${encodeURIComponent(topic)}`,
         { method: "POST" },
       );
@@ -63,8 +69,8 @@ export default function NewsPage() {
       if (typeof r.updated === "number") parts.push(`aktualisiert ${r.updated}`);
       setMsg(parts.join(" | "));
       await load();
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setRefreshing(false);
     }

--- a/apps/web/app/ops/page.tsx
+++ b/apps/web/app/ops/page.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { apiFetch } from "../../lib/api";
 import Badge from "../components/Badge";
 import { DataQualityFlag } from "../types";
+import { toErrorMessage } from "../utils/error";
 
 type JobResponse = { status: string; task_id: string; report_id: number; message: string };
+type EntityType = "cooperative" | "roaster" | "both";
+type NewsRefreshResponse = { status: string; created?: number; updated?: number; errors?: unknown[] };
+
+function parseEntityType(value: string): EntityType {
+  if (value === "cooperative" || value === "roaster" || value === "both") {
+    return value;
+  }
+  return "both";
+}
 
 type OpsOverview = {
   data_quality: {
@@ -20,7 +30,7 @@ function OpsPageContent() {
   const searchParams = useSearchParams();
   const [health, setHealth] = useState<string>("");
   const [topic, setTopic] = useState("peru coffee");
-  const [entityType, setEntityType] = useState<"cooperative" | "roaster" | "both">("both");
+  const [entityType, setEntityType] = useState<EntityType>("both");
   const [max, setMax] = useState(50);
   const [log, setLog] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
@@ -31,22 +41,22 @@ function OpsPageContent() {
   const [dqEntityType, setDqEntityType] = useState<string>("all");
   const [dqIncludeResolved, setDqIncludeResolved] = useState(false);
 
-  function push(line: string) {
+  const push = useCallback((line: string) => {
     setLog((prev) => [`${new Date().toLocaleTimeString()}  ${line}`, ...prev].slice(0, 120));
-  }
+  }, []);
 
-  async function ping() {
+  const ping = useCallback(async () => {
     try {
       const d = await apiFetch<{ status: string }>("/health");
       setHealth(d.status);
       push(`health: ${d.status}`);
-    } catch (e: any) {
+    } catch (error: unknown) {
       setHealth("down");
-      push(`health: ERROR ${e?.message ?? e}`);
+      push(`health: ERROR ${toErrorMessage(error)}`);
     }
-  }
+  }, [push]);
 
-  async function loadQuality() {
+  const loadQuality = useCallback(async () => {
     setQualityBusy(true);
     try {
       const qs = new URLSearchParams();
@@ -60,16 +70,16 @@ function OpsPageContent() {
       ]);
       setOverview(o);
       setFlags(f.slice(0, 12));
-    } catch (e: any) {
-      push(`data-quality: ERROR ${e?.message ?? e}`);
+    } catch (error: unknown) {
+      push(`data-quality: ERROR ${toErrorMessage(error)}`);
     } finally {
       setQualityBusy(false);
     }
-  }
+  }, [dqEntityType, dqIncludeResolved, dqSeverity, push]);
 
   useEffect(() => {
     ping();
-  }, []);
+  }, [ping]);
 
   useEffect(() => {
     if (!searchParams) return;
@@ -85,16 +95,16 @@ function OpsPageContent() {
 
   useEffect(() => {
     loadQuality();
-  }, [dqSeverity, dqEntityType, dqIncludeResolved]);
+  }, [loadQuality]);
 
-  async function run(name: string, fn: () => Promise<any>) {
+  async function run(name: string, fn: () => Promise<unknown>) {
     setBusy(true);
     try {
       push(`${name}...`);
       const r = await fn();
       push(`${name}: OK ${JSON.stringify(r)}`);
-    } catch (e: any) {
-      push(`${name}: ERROR ${e?.message ?? e}`);
+    } catch (error: unknown) {
+      push(`${name}: ERROR ${toErrorMessage(error)}`);
     } finally {
       setBusy(false);
     }
@@ -105,8 +115,8 @@ function OpsPageContent() {
     try {
       await apiFetch(`/data-quality/flags/${id}/resolve`, { method: "POST" });
       await loadQuality();
-    } catch (e: any) {
-      push(`resolve-flag: ERROR ${e?.message ?? e}`);
+    } catch (error: unknown) {
+      push(`resolve-flag: ERROR ${toErrorMessage(error)}`);
     } finally {
       setQualityBusy(false);
     }
@@ -119,8 +129,8 @@ function OpsPageContent() {
         method: "POST",
       });
       await loadQuality();
-    } catch (e: any) {
-      push(`recompute: ERROR ${e?.message ?? e}`);
+    } catch (error: unknown) {
+      push(`recompute: ERROR ${toErrorMessage(error)}`);
     } finally {
       setQualityBusy(false);
     }
@@ -171,7 +181,7 @@ function OpsPageContent() {
               disabled={busy}
               onClick={() =>
                 run("News refresh", async () => {
-                  return apiFetch<any>(`/news/refresh?topic=${encodeURIComponent(topic)}`, {
+                  return apiFetch<NewsRefreshResponse>(`/news/refresh?topic=${encodeURIComponent(topic)}`, {
                     method: "POST",
                   });
                 })
@@ -199,7 +209,7 @@ function OpsPageContent() {
               <select
                 className="input"
                 value={entityType}
-                onChange={(e) => setEntityType(e.target.value as any)}
+                onChange={(e) => setEntityType(parseEntityType(e.target.value))}
                 style={{ width: 220 }}
               >
                 <option value="both">beide</option>
@@ -225,7 +235,7 @@ function OpsPageContent() {
                 disabled={busy}
                 onClick={() =>
                   run("Seed discovery", async () => {
-                    return apiFetch<any>("/discovery/seed", {
+                    return apiFetch<JobResponse>("/discovery/seed", {
                       method: "POST",
                       body: JSON.stringify({
                         entity_type: entityType,

--- a/apps/web/app/reports/[id]/page.tsx
+++ b/apps/web/app/reports/[id]/page.tsx
@@ -12,7 +12,7 @@ type Report = {
   title: string | null;
   report_at: string;
   markdown: string;
-  payload: any;
+  payload: unknown;
 };
 
 export default function ReportDetailPage() {

--- a/apps/web/app/roasters/[id]/page.tsx
+++ b/apps/web/app/roasters/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter } from "next/navigation";
 import { apiFetch } from "../../../lib/api";
 import Badge from "../../components/Badge";
 import { DataQualityFlag } from "../../types";
+import { toErrorMessage } from "../../utils/error";
 
 type Roaster = {
   id: number;
@@ -38,8 +39,8 @@ export default function RoasterDetailPage() {
         ]);
         setR(d);
         setFlags(f);
-      } catch (e: any) {
-        setErr(e?.message ?? String(e));
+      } catch (error: unknown) {
+        setErr(toErrorMessage(error));
       }
     })();
   }, [id]);
@@ -52,8 +53,8 @@ export default function RoasterDetailPage() {
         `/data-quality/flags?entity_type=roaster&entity_id=${id}`,
       );
       setFlags(f);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setQualityBusy(false);
     }
@@ -67,8 +68,8 @@ export default function RoasterDetailPage() {
         `/data-quality/flags?entity_type=roaster&entity_id=${id}`,
       );
       setFlags(f);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setQualityBusy(false);
     }
@@ -92,8 +93,8 @@ export default function RoasterDetailPage() {
       });
       setR(d);
       setMsg("Gespeichert.");
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setSaving(false);
     }
@@ -106,8 +107,8 @@ export default function RoasterDetailPage() {
     try {
       await apiFetch(`/roasters/${id}`, { method: "DELETE" });
       router.push("/roasters");
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     }
   }
 
@@ -120,8 +121,8 @@ export default function RoasterDetailPage() {
       });
       setR(restored);
       setMsg("Wiederhergestellt.");
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     }
   }
 

--- a/apps/web/app/roasters/page.tsx
+++ b/apps/web/app/roasters/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { apiFetch } from "../../lib/api";
 import Badge from "../components/Badge";
 import { DataQualityFlag } from "../types";
+import { toErrorMessage } from "../utils/error";
 
 type Roaster = {
   id: number;
@@ -18,17 +19,24 @@ type Roaster = {
 type RoasterList = { items: Roaster[]; total: number };
 
 type FlagSummary = { count: number; tone: "bad" | "warn" | "neutral" };
+type DqFilter = "all" | "any" | "none" | "critical" | "warning" | "info";
+
+const DQ_FILTER_VALUES: DqFilter[] = ["all", "any", "none", "critical", "warning", "info"];
+
+function parseDqFilter(value: string): DqFilter {
+  return DQ_FILTER_VALUES.includes(value as DqFilter) ? (value as DqFilter) : "all";
+}
 
 export default function RoastersPage() {
   const [data, setData] = useState<RoasterList | null>(null);
   const [flagSummary, setFlagSummary] = useState<Record<number, FlagSummary>>({});
   const [q, setQ] = useState("");
   const [showArchived, setShowArchived] = useState(false);
-  const [dqFilter, setDqFilter] = useState<"all" | "any" | "none" | "critical" | "warning" | "info">("all");
+  const [dqFilter, setDqFilter] = useState<DqFilter>("all");
   const [busyId, setBusyId] = useState<number | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
-  async function load() {
+  const load = useCallback(async () => {
     try {
       const [res, flags] = await Promise.all([
         apiFetch<Roaster[] | RoasterList>(
@@ -59,14 +67,14 @@ export default function RoastersPage() {
         }
       }
       setFlagSummary(summary);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     }
-  }
+  }, [showArchived]);
 
   useEffect(() => {
-    load();
-  }, [showArchived]);
+    void load();
+  }, [load]);
 
   async function archiveRoaster(id: number) {
     if (!confirm("Roesterei archivieren?")) return;
@@ -74,8 +82,8 @@ export default function RoastersPage() {
     try {
       await apiFetch(`/roasters/${id}`, { method: "DELETE" });
       await load();
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setBusyId(null);
     }
@@ -86,8 +94,8 @@ export default function RoastersPage() {
     try {
       await apiFetch(`/roasters/${id}/restore`, { method: "POST" });
       await load();
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
     } finally {
       setBusyId(null);
     }
@@ -146,7 +154,7 @@ export default function RoastersPage() {
           <select
             className="input"
             value={dqFilter}
-            onChange={(e) => setDqFilter(e.target.value as any)}
+            onChange={(e) => setDqFilter(parseDqFilter(e.target.value))}
             style={{ width: 160 }}
           >
             <option value="all">DQ: alle</option>

--- a/apps/web/app/sentiment/page.tsx
+++ b/apps/web/app/sentiment/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { apiFetch } from "../../lib/api";
 import LineChart from "../charts/LineChart";
 import Badge from "../components/Badge";
+import { toErrorMessage } from "../utils/error";
 
 type SentimentPoint = {
   id: number;
@@ -42,8 +43,8 @@ export default function SentimentPage() {
     try {
       const res = await apiFetch<SentimentResponse>(`/sentiment/${encodeURIComponent(r)}`);
       setData(res.data);
-    } catch (e: any) {
-      setErr(e?.message ?? String(e));
+    } catch (error: unknown) {
+      setErr(toErrorMessage(error));
       setData([]);
     } finally {
       setLoading(false);

--- a/apps/web/app/shipments/page.tsx
+++ b/apps/web/app/shipments/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { format, differenceInDays } from "date-fns";
 import { useShipments, useCreateShipment } from "../hooks/useShipments";
 import { apiFetch } from "../../lib/api";
@@ -27,8 +27,7 @@ export default function ShipmentsDashboard() {
     include_deleted: showArchived,
   });
   const createShipment = useCreateShipment();
-  const [now, setNow] = useState(0);
-  useEffect(() => setNow(Date.now()), []);
+  const [now] = useState(() => Date.now());
 
   const shipments = shipmentsResponse?.items ?? [];
   const activeShipments = shipments.filter((s) => !s.deleted_at);

--- a/apps/web/app/types/index.ts
+++ b/apps/web/app/types/index.ts
@@ -1,5 +1,9 @@
 // TypeScript types matching backend Pydantic schemas
 
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
 // Multi-Country Support
 export type SupportedCountry = "PE" | "CO" | "ET" | "BR";
 
@@ -181,7 +185,7 @@ export interface Shipment {
   status_updated_at: string | null;
   delay_hours: number;
   notes: string | null;
-  tracking_events: any[] | null;
+  tracking_events: JsonValue[] | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
@@ -220,10 +224,10 @@ export interface Deal {
   process_method: string | null;
   quality_grade: string | null;
   cupping_score: number | null;
-  certifications: Record<string, any> | null;
+  certifications: JsonObject | null;
   closed_at: string | null;
   notes: string | null;
-  meta: Record<string, any> | null;
+  meta: JsonObject | null;
   created_at: string;
   updated_at: string;
   deleted_at?: string | null;
@@ -247,10 +251,10 @@ export interface CreateDealRequest {
   process_method?: string;
   quality_grade?: string;
   cupping_score?: number;
-  certifications?: Record<string, any>;
+  certifications?: JsonObject;
   closed_at?: string;
   notes?: string;
-  meta?: Record<string, any>;
+  meta?: JsonObject;
 }
 
 export interface UpdateDealRequest {
@@ -270,10 +274,10 @@ export interface UpdateDealRequest {
   process_method?: string;
   quality_grade?: string;
   cupping_score?: number;
-  certifications?: Record<string, any>;
+  certifications?: JsonObject;
   closed_at?: string;
   notes?: string;
-  meta?: Record<string, any>;
+  meta?: JsonObject;
 }
 
 export interface MarginCalcRequest {
@@ -289,8 +293,8 @@ export interface MarginCalcRequest {
 
 export interface MarginCalcResult {
   computed_at: string;
-  inputs: Record<string, any>;
-  outputs: Record<string, any>;
+  inputs: JsonObject;
+  outputs: JsonObject;
 }
 
 // Margin Run type

--- a/apps/web/app/utils/error.ts
+++ b/apps/web/app/utils/error.ts
@@ -1,0 +1,6 @@
+export function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -52,7 +52,7 @@ export function apiBaseUrl(): string {
   return "http://localhost:8000";
 }
 
-export async function apiFetch<T = any>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+export async function apiFetch<T = unknown>(path: string, options: ApiFetchOptions = {}): Promise<T> {
   const { skipAuth, ...req } = options;
 
   const token = !skipAuth ? getToken() : null;


### PR DESCRIPTION
## Summary
- remove remaining frontend eslint warnings across dashboard, deals, ops, dedup, lots, news and detail pages
- replace unsafe any usages with typed structures and unknown error handling
- stabilize hook dependencies with useCallback where required (react-hooks/exhaustive-deps)
- add shared toErrorMessage helper and reuse it in pages/hooks
- tighten API generic defaults (unknown instead of any) and JSON typing in shared app types

## Validation
- npm run lint (apps/web) ✅
- npx tsc --noEmit (apps/web) ✅
- docker system df before/after cleanup measured
- docker system prune -af reclaimed ~870.8MB

## Notes
- local next build still fails in this environment with Windows spawn EPERM after successful compile, while standalone TypeScript check passes (npx tsc --noEmit).