### PR TITLE
fix(api,ci): close remaining alias and docker workflow issues

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-backend:
     name: Build & Push Backend Image
@@ -243,11 +246,11 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.34.1
         with:
-          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ github.ref_name }}-${{ github.sha }}
+          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ github.ref_name }}
           format: 'sarif'
           output: 'trivy-${{ matrix.image }}-results.sarif'
           severity: 'CRITICAL,HIGH'
-        continue-on-error: true
+          exit-code: '0'
       
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/apps/api/app/api/routes/peru_sourcing.py
+++ b/apps/api/app/api/routes/peru_sourcing.py
@@ -52,7 +52,8 @@ def list_peru_regions(
 
 
 @router.get(
-    "/regions/{region_name}/intelligence", response_model=RegionIntelligenceResponse
+    "/regions/{region_name:path}/intelligence",
+    response_model=RegionIntelligenceResponse,
 )
 def get_region_intelligence(
     region_name: str,

--- a/apps/api/app/services/peru_sourcing_intel.py
+++ b/apps/api/app/services/peru_sourcing_intel.py
@@ -8,6 +8,8 @@ Provides comprehensive intelligence on Peru coffee regions including:
 - External data integration
 """
 
+import re
+import unicodedata
 from typing import Any
 from sqlalchemy.orm import Session
 from sqlalchemy import select
@@ -26,6 +28,38 @@ class PeruRegionIntelService:
     def __init__(self, db: Session):
         self.db = db
 
+    @staticmethod
+    def _normalize_region_name(value: str) -> str:
+        """Normalize region names for robust matching.
+
+        Handles frontend display names like "Junín (Satipo/Chanchamayo)" by
+        removing parenthetical qualifiers and diacritics.
+        """
+        base = re.sub(r"\s*\(.*\)\s*$", "", (value or "").strip())
+        no_diacritics = "".join(
+            ch
+            for ch in unicodedata.normalize("NFKD", base)
+            if not unicodedata.combining(ch)
+        )
+        return re.sub(r"\s+", " ", no_diacritics).strip().lower()
+
+    def _resolve_region(self, region_name: str) -> Region | None:
+        """Resolve a Peru region by exact or normalized alias name."""
+        exact_stmt = select(Region).where(
+            Region.name == region_name, Region.country == "Peru"
+        )
+        exact_region = self.db.scalar(exact_stmt)
+        if exact_region:
+            return exact_region
+
+        target = self._normalize_region_name(region_name)
+        stmt = select(Region).where(Region.country == "Peru")
+        regions = self.db.scalars(stmt).all()
+        for region in regions:
+            if self._normalize_region_name(region.name) == target:
+                return region
+        return None
+
     def get_region_intelligence(self, region_name: str) -> dict[str, Any] | None:
         """
         Get comprehensive intelligence for a Peru coffee region.
@@ -36,10 +70,7 @@ class PeruRegionIntelService:
         Returns:
             Dictionary with region intelligence or None if not found
         """
-        stmt = select(Region).where(
-            Region.name == region_name, Region.country == "Peru"
-        )
-        region = self.db.scalar(stmt)
+        region = self._resolve_region(region_name)
 
         if not region:
             return None
@@ -176,18 +207,13 @@ class PeruRegionIntelService:
         Returns:
             Dictionary with refresh status and data sources
         """
-        from sqlalchemy import select
+        region = self._resolve_region(region_name)
+        lookup_name = region.name if region else region_name
 
-        # Fetch from external sources
-        jnc_data = fetch_jnc_data(region_name)
-        minagri_data = fetch_minagri_data(region_name)
-        weather_data = fetch_senamhi_weather(region_name)
-
-        # Update region model with fresh data
-        stmt = select(Region).where(
-            Region.name == region_name, Region.country == "Peru"
-        )
-        region = self.db.scalar(stmt)
+        # Fetch from external sources using canonical name when available
+        jnc_data = fetch_jnc_data(lookup_name)
+        minagri_data = fetch_minagri_data(lookup_name)
+        weather_data = fetch_senamhi_weather(lookup_name)
 
         updated_fields = []
 
@@ -203,7 +229,7 @@ class PeruRegionIntelService:
             self.db.commit()
 
         return {
-            "region": region_name,
+            "region": lookup_name,
             "refreshed": True,
             "updated_fields": updated_fields,
             "sources": {

--- a/apps/api/tests/test_peru_sourcing_api.py
+++ b/apps/api/tests/test_peru_sourcing_api.py
@@ -77,6 +77,19 @@ def test_get_region_intelligence_not_found(client, auth_headers, db):
         pass
 
 
+def test_get_region_intelligence_alias_name(client, auth_headers, db):
+    """Test region intelligence accepts frontend display aliases with qualifiers."""
+    client.post("/peru/regions/seed", headers=auth_headers)
+
+    response = client.get(
+        "/peru/regions/Jun%C3%ADn%20(Satipo%2FChanchamayo)/intelligence",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Junín"
+
+
 def test_analyze_cooperative_not_found(client, auth_headers, db):
     """Test analyzing non-existent cooperative."""
     response = client.post("/peru/cooperatives/99999/analyze", headers=auth_headers)
@@ -190,3 +203,17 @@ def test_refresh_region_data(client, auth_headers, db):
     assert data["region"] == "Cajamarca"
     assert data["refreshed"] is True
     assert "sources" in data
+
+
+def test_refresh_region_data_alias_name(client, auth_headers, db):
+    """Test refreshing with frontend display alias resolves to canonical region."""
+    client.post("/peru/regions/seed", headers=auth_headers)
+
+    response = client.post(
+        "/peru/regions/refresh",
+        json={"region_name": "Cusco (La Convención)"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["region"] == "Cusco"


### PR DESCRIPTION
## Summary
- support frontend region aliases (including diacritics + parenthetical qualifiers) in Peru sourcing intelligence endpoints
- switch Peru intelligence route parameter to path mode so encoded names with slashes work reliably
- add regression tests for alias-based intelligence lookup and alias-based refresh
- harden Docker image workflow scans:
  - opt in to Node 24 execution for GitHub actions in this workflow
  - scan pushed branch tags that actually exist
  - keep Trivy SARIF generation non-blocking via explicit exit-code 0 to avoid noisy false-fail annotations

## Validation
- pytest apps/api/tests/test_peru_sourcing_api.py -q ✅
- pytest apps/api/tests -q ✅
- pytest tests -q ✅
- python -m ruff check apps/api ✅
- python -m mypy apps/api/app ✅
- npm run lint (apps/web) ✅
- npm run build (apps/web, outside sandbox) ✅
- docker compose config ✅
- docker compose build frontend ✅
- docker compose build backend ✅
- docker compose up -d + health smoke (/health + frontend) ✅