### PR TITLE
fix(ci): skip sarif upload for empty trivy runs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -264,9 +264,23 @@ jobs:
           }
           EOF
 
+      - name: Check SARIF upload eligibility
+        id: sarif_check
+        run: |
+          FILE="trivy-${{ matrix.image }}-results.sarif"
+          if [ ! -f "$FILE" ]; then
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -Eq '"runs"[[:space:]]*:[[:space:]]*\[[[:space:]]*\]' "$FILE"; then
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-${{ matrix.image }}-results.sarif'
           category: 'trivy-${{ matrix.image }}-pushed'
-        if: always() && hashFiles('trivy-*.sarif') != ''
+        if: always() && steps.sarif_check.outputs.upload == 'true'


### PR DESCRIPTION
## Summary
- add an explicit SARIF eligibility check before upload
- skip upload when Trivy output only contains an empty `runs` array
- prevent false-failing Docker workflow runs from GitHub SARIF API validation errors

## Validation
- workflow YAML parsed successfully (`docker-build.yml`)
- addresses failure mode seen in run `22956033046` (`Invalid request. 1 item required; only 0 were supplied`)