### PR TITLE
fix(ci): modernize docker workflow action versions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,21 +31,21 @@ jobs:
       HAS_DOCKER_HUB: ${{ secrets.DOCKER_USERNAME != '' }}
       DO_PUSH: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_call' && inputs.push_images == true) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Log in to Docker Hub
         if: env.HAS_DOCKER_HUB == 'true' && env.DO_PUSH == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       
       - name: Log in to GitHub Container Registry
         if: env.DO_PUSH == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -131,21 +131,21 @@ jobs:
       HAS_DOCKER_HUB: ${{ secrets.DOCKER_USERNAME != '' }}
       DO_PUSH: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_call' && inputs.push_images == true) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Log in to Docker Hub
         if: env.HAS_DOCKER_HUB == 'true' && env.DO_PUSH == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       
       - name: Log in to GitHub Container Registry
         if: env.DO_PUSH == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -238,7 +238,7 @@ jobs:
     
     steps:
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -252,6 +252,7 @@ jobs:
           output: 'trivy-${{ matrix.image }}-results.sarif'
           severity: 'CRITICAL,HIGH'
           exit-code: '0'
+          cache: false
         continue-on-error: true
 
       - name: Ensure SARIF file exists


### PR DESCRIPTION
## Summary
- update Docker workflow actions to current major versions:
  - `actions/checkout@v6`
  - `docker/setup-buildx-action@v4`
  - `docker/login-action@v4`
- disable Trivy action cache to avoid deprecated `actions/cache` usage in this workflow

## Why
Reduces Node 20 deprecation noise and keeps the Docker pipeline aligned with current GitHub Actions runtime expectations.

## Validation
- workflow YAML parsed successfully (`docker-build.yml`)