### PR TITLE
fix(ci): improve Sonar gating and add optional Vercel deploy

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,30 +1,29 @@
-﻿name: SonarQube Cloud (CI-based, optional)
+name: SonarQube / SonarCloud Scan (optional)
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:
   sonar:
-    if: ${{ vars.SONAR_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ secrets.SONAR_TOKEN != '' && vars.SONAR_PROJECT_KEY != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-          cache: 'pip'
+          python-version: "3.12"
+          cache: pip
           cache-dependency-path: |
             apps/api/requirements.txt
             apps/api/requirements-dev.txt
@@ -44,15 +43,31 @@ jobs:
           cd apps/api
           pytest tests/ -q --cov=app --cov-report=xml:coverage.xml
 
+      - name: Build Sonar arguments
+        id: sonar_args
+        shell: bash
+        run: |
+          args="-Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}"
+          args="$args -Dsonar.sources=apps/api/app"
+          args="$args -Dsonar.tests=apps/api/tests"
+          args="$args -Dsonar.python.coverage.reportPaths=apps/api/coverage.xml"
+          if [ -n "${{ vars.SONAR_ORGANIZATION }}" ]; then
+            args="$args -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}"
+          fi
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+
       - name: Sonar scan (Python coverage)
         uses: SonarSource/sonarqube-scan-action@v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL != '' && secrets.SONAR_HOST_URL || 'https://sonarcloud.io' }}
         with:
-          args: >
-            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
-            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
-            -Dsonar.sources=apps/api/app
-            -Dsonar.tests=apps/api/tests
-            -Dsonar.python.coverage.reportPaths=apps/api/coverage.xml
+          args: ${{ steps.sonar_args.outputs.args }}
+
+  sonar-disabled:
+    if: ${{ !(secrets.SONAR_TOKEN != '' && vars.SONAR_PROJECT_KEY != '') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain why sonar is skipped
+        run: |
+          echo "Skipping Sonar scan: missing SONAR_TOKEN or SONAR_PROJECT_KEY."

--- a/.github/workflows/sonar_issues_sync.yml
+++ b/.github/workflows/sonar_issues_sync.yml
@@ -15,11 +15,12 @@ concurrency:
 
 jobs:
   sync:
+    if: ${{ secrets.SONAR_TOKEN != '' && vars.SONAR_PROJECT_KEY != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -43,3 +44,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python scripts/automation/sonar_sync_issues.py
+
+  sync-disabled:
+    if: ${{ !(secrets.SONAR_TOKEN != '' && vars.SONAR_PROJECT_KEY != '') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain why sync is skipped
+        run: |
+          echo "Skipping Sonar issue sync: missing SONAR_TOKEN or SONAR_PROJECT_KEY."

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,0 +1,97 @@
+name: Vercel Deploy (optional)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: vercel-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: apps/web
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment (preview)
+        if: github.event_name == 'pull_request'
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      - name: Pull Vercel Environment (production)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build Vercel Artifact
+        run: vercel build --token="$VERCEL_TOKEN"
+
+      - name: Deploy Preview
+        id: deploy_preview
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          URL=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Preview URL: $URL"
+
+      - name: Deploy Production
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          URL=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+          echo "Production URL: $URL"
+
+      - name: Comment Preview URL
+        if: github.event_name == 'pull_request' && steps.deploy_preview.outputs.url != ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Vercel Preview: ${process.env.PREVIEW_URL}`
+            })
+        env:
+          PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}
+
+  deploy-disabled:
+    if: ${{ !(secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain why deploy is skipped
+        run: |
+          echo "Skipping Vercel deploy: missing VERCEL_TOKEN / VERCEL_ORG_ID / VERCEL_PROJECT_ID."

--- a/docs/operations/CI_SECRETS.md
+++ b/docs/operations/CI_SECRETS.md
@@ -1,45 +1,31 @@
-# CI Secrets (GitHub Actions)
+# CI Secrets
 
-This file documents the repository secrets required by the enterprise CI workflows and recommended scopes.
+This file documents repository-level secrets and variables used by GitHub Actions workflows.
 
-Required secrets
-- `SONAR_TOKEN` — SonarCloud token with project analyze permissions.
-- `CODECOV_TOKEN` — Codecov upload token (if using Codecov).
-- `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` — (or `GHCR_TOKEN`) for publishing images from workflows.
-- `PYPI_API_TOKEN` — (optional) for publishing packages.
-- `SLS_TOKEN` / `SENTRY_DSN` — (optional) for error reporting in CI.
+## Required for Core CI
+- `SONAR_TOKEN`: token for SonarQube/SonarCloud scan upload.
+- `SONAR_PROJECT_KEY` (repository variable): project key used by Sonar scanner.
+- `CODECOV_TOKEN` (optional): enables Codecov coverage upload if configured.
 
-Recommended setup steps
-1. Go to the repository on GitHub → Settings → Secrets and variables → Actions → New repository secret.
-2. Paste the token value and use the secret name above.
-3. For `SONAR_TOKEN`, also ensure the SonarCloud organization has the project key matching this repo.
+## Required for Docker Image Publishing
+- `DOCKER_USERNAME`
+- `DOCKER_PASSWORD`
 
-Notes on minimal scopes
-- `SONAR_TOKEN`: token generated from SonarCloud user/account with 'Execute Analysis' rights.
-- `CODECOV_TOKEN`: project token from Codecov; keep private.
-- Docker registry tokens: only give push access for the specific repository/namespace.
+If Docker Hub credentials are not set, workflows still publish to GHCR where configured.
 
-CI troubleshooting
-- If Sonar or Codecov steps fail with 401/403, verify the token in the UI and the repository/org membership for the token owner.
-- For private registries: confirm the runner has network access to the registry and credentials are current.
+## Required for Vercel Deploy Workflow
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
 
-Reference
-- See `.github/workflows/sonarcloud.yml` and `.github/workflows/smoke-check.yml` for which secrets are referenced.
-# CI Secrets Checklist
+When these are missing, `.github/workflows/vercel.yml` exits cleanly with a skip message.
 
-This document lists the repository secrets required to enable full CI, coverage and security scans.
+## Optional Sonar Variables
+- `SONAR_ORGANIZATION` (for SonarCloud)
+- `SONAR_HOST_URL` (secret, for self-hosted SonarQube; defaults to `https://sonarcloud.io` when not set)
+- `SONAR_BRANCH`, `SONAR_SEVERITIES`, `SONAR_STATUSES`, `SONAR_MAX_CREATE`, `SONAR_LABEL`, `SONAR_AUTO_CLOSE` (used by Sonar issues sync workflow)
 
-Required GitHub Secrets
-
-- `CODECOV_TOKEN`: Token for Codecov to upload coverage reports. Add via repo Settings → Secrets.
-- `SONAR_TOKEN`: SonarCloud (or SonarQube) token for analysis upload.
-- `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD`: If CI pushes images to a private registry.
-- `PYPI_API_TOKEN` (optional): For publishing Python packages if configured.
-
-How to add
-1. Go to repository Settings → Secrets → Actions
-2. Add a new secret with name and value
-3. Keep tokens secure; do not commit them into the repo
-
-Notes
-- After adding `CODECOV_TOKEN` and `SONAR_TOKEN`, re-run CI to populate badges and dashboards.
+## Notes
+- Add secrets under: `Repository Settings -> Secrets and variables -> Actions`.
+- Add non-secret parameters (for example `SONAR_PROJECT_KEY`) under repository variables.
+- For pull requests from forks, secrets are intentionally unavailable; optional workflows are skipped by design.

--- a/docs/operations/SONARQUBE.md
+++ b/docs/operations/SONARQUBE.md
@@ -1,22 +1,24 @@
 # SonarQube / SonarCloud Integration
 
-This document explains the minimal SonarCloud integration scaffold added to the repository.
+This repository uses `.github/workflows/sonar.yml` for optional Sonar analysis.
 
-What was added
-- `.github/workflows/sonarcloud.yml` — GitHub Actions workflow that runs SonarCloud analysis on push/PR.
-- `sonar.projectKey` and `sonar.organization` are configured in the workflow. You must update these values for your SonarCloud organization if different.
+## Workflow Behavior
+- Runs on `push` to `main`, PR updates, and manual dispatch.
+- Automatically skips (green) when required Sonar credentials are missing.
+- Runs API tests with coverage and uploads coverage-aware scan results.
 
-Requirements
-- Create a repository secret `SONAR_TOKEN` with a SonarCloud token (or SonarQube token if using self-hosted scanner).
-- If you use SonarCloud, register the project under your organization and update `sonar.projectKey`.
+## Required Configuration
+- Secret: `SONAR_TOKEN`
+- Variable: `SONAR_PROJECT_KEY`
 
-How it works
-- The workflow installs Python dependencies and runs the SonarCloud GitHub Action.
-- The action uploads analysis results to SonarCloud where you can see security hotspots, code smells, and metric trends.
+## Optional Configuration
+- Variable: `SONAR_ORGANIZATION` (required for SonarCloud org mapping)
+- Secret: `SONAR_HOST_URL` (set for self-hosted SonarQube; defaults to SonarCloud URL if absent)
 
-Local testing
-- You can run `sonar-scanner` locally against the codebase if you have SonarQube installed.
+## Sonar Issue Sync
+- `.github/workflows/sonar_issues_sync.yml` syncs Sonar issues into GitHub issues.
+- It also skips cleanly when `SONAR_TOKEN` or `SONAR_PROJECT_KEY` is missing.
 
-More
+## References
 - SonarCloud docs: https://sonarcloud.io/documentation
-- Self-hosted SonarQube: https://docs.sonarqube.org
+- SonarQube docs: https://docs.sonarsource.com/sonarqube-server


### PR DESCRIPTION
## Summary
- modernize Sonar workflow gating: run when `SONAR_TOKEN` + `SONAR_PROJECT_KEY` exist, otherwise clean skip job
- support both SonarCloud and self-hosted SonarQube via defaulted `SONAR_HOST_URL`
- make Sonar issue sync workflow non-failing when Sonar credentials are absent
- add optional Vercel deployment workflow for preview (PR) and production (main)
- update operations docs for Sonar and Vercel secrets/variables

## Validation
- all modified workflows parse as valid YAML
- local repo changes isolated to workflow and operations docs