### PR TITLE
fix(vercel): run checks before apps/web working directory

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -18,9 +18,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    defaults:
-      run:
-        working-directory: apps/web
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -49,14 +46,17 @@ jobs:
 
       - name: Install dependencies
         if: steps.vercel_config.outputs.enabled == 'true'
+        working-directory: apps/web
         run: npm ci --no-audit --no-fund
 
       - name: Lint
         if: steps.vercel_config.outputs.enabled == 'true'
+        working-directory: apps/web
         run: npm run lint
 
       - name: Build
         if: steps.vercel_config.outputs.enabled == 'true'
+        working-directory: apps/web
         run: npm run build
 
       - name: Install Vercel CLI
@@ -65,20 +65,24 @@ jobs:
 
       - name: Pull Vercel Environment (preview)
         if: steps.vercel_config.outputs.enabled == 'true' && github.event_name == 'pull_request'
+        working-directory: apps/web
         run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
 
       - name: Pull Vercel Environment (production)
         if: steps.vercel_config.outputs.enabled == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: apps/web
         run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Build Vercel Artifact
         if: steps.vercel_config.outputs.enabled == 'true'
+        working-directory: apps/web
         run: vercel build --token="$VERCEL_TOKEN"
 
       - name: Deploy Preview
         id: deploy_preview
         if: steps.vercel_config.outputs.enabled == 'true' && github.event_name == 'pull_request'
         shell: bash
+        working-directory: apps/web
         run: |
           URL=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
           echo "url=$URL" >> "$GITHUB_OUTPUT"
@@ -87,6 +91,7 @@ jobs:
       - name: Deploy Production
         if: steps.vercel_config.outputs.enabled == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
+        working-directory: apps/web
         run: |
           URL=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
           echo "Production URL: $URL"


### PR DESCRIPTION
## Summary
- remove job-level default working-directory (pps/web) that was applied before checkout
- set working-directory: apps/web only on run steps that actually need repository files
- keeps optional Vercel workflow green when secrets are missing

## Root cause
The first step (Check Vercel configuration) executed before checkout, but inherited working-directory: apps/web, which does not exist yet on a fresh runner.

## Validation
- YAML parse passes for .github/workflows/vercel.yml
- logic validated against failed run log (No such file or directory on pre-check step)