### PR TITLE
fix(sonar): avoid coverage threshold blocking optional scan

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -55,7 +55,7 @@ jobs:
           JWT_SECRET: test_secret_key_for_ci_minimum_32_characters_long
         run: |
           cd apps/api
-          pytest tests/ -q --cov=app --cov-report=xml:coverage.xml
+          pytest tests/ -q --cov=app --cov-report=xml:coverage.xml --cov-fail-under=0
 
       - name: Build Sonar arguments
         if: steps.sonar_config.outputs.enabled == 'true'


### PR DESCRIPTION
## Summary
- keep Sonar workflow test execution for coverage XML generation
- disable fail-under gate in this workflow by adding --cov-fail-under=0

## Why
The optional Sonar workflow failed before scan upload due to repository-wide coverage threshold (75%) enforced by pytest-cov. This workflow should generate reports for Sonar; quality gating remains in primary CI workflows.

## Validation
- YAML parse succeeds for .github/workflows/sonar.yml
- reproduced failure root cause from run 22991368523 and addressed directly