### PR TITLE
fix(sonar): skip optional scan when org var is missing

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -19,10 +19,15 @@ jobs:
         id: sonar_config
         shell: bash
         run: |
-          if [ -n "${{ secrets.SONAR_TOKEN }}" ] && [ -n "${{ vars.SONAR_PROJECT_KEY }}" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ -z "${{ secrets.SONAR_TOKEN }}" ] || [ -z "${{ vars.SONAR_PROJECT_KEY }}" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "reason=missing SONAR_TOKEN or SONAR_PROJECT_KEY" >> "$GITHUB_OUTPUT"
+          elif [ -z "${{ secrets.SONAR_HOST_URL }}" ] && [ -z "${{ vars.SONAR_ORGANIZATION }}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "reason=missing SONAR_ORGANIZATION for SonarCloud" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "reason=ok" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v6
@@ -83,4 +88,4 @@ jobs:
       - name: Explain why sonar is skipped
         if: steps.sonar_config.outputs.enabled != 'true'
         run: |
-          echo "Skipping Sonar scan: missing SONAR_TOKEN or SONAR_PROJECT_KEY."
+          echo "Skipping Sonar scan: ${{ steps.sonar_config.outputs.reason }}"


### PR DESCRIPTION
## Summary
- improve Sonar config guard in .github/workflows/sonar.yml
- skip optional Sonar scan when both conditions are true:
  - SonarCloud default host is used (no SONAR_HOST_URL secret)
  - SONAR_ORGANIZATION variable is missing
- preserve execution when self-hosted SonarQube (SONAR_HOST_URL) is configured
- provide explicit skip reason in logs

## Why
Latest run failed with: You must define ... sonar.organization. This should be a clean skip in optional mode, not a red workflow.

## Validation
- YAML parse successful
- skip messaging uses computed reason output