### PR TITLE
fix(sonarcloud): disable automatic analysis for CI scans

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -62,6 +62,25 @@ jobs:
           cd apps/api
           pytest tests/ -q --cov=app --cov-report=xml:coverage.xml --cov-fail-under=0
 
+      - name: Disable SonarCloud Automatic Analysis
+        if: steps.sonar_config.outputs.enabled == 'true' && secrets.SONAR_HOST_URL == ''
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+        shell: bash
+        run: |
+          http_code=$(curl -sS -o autoscan_response.json -w "%{http_code}" \
+            -u "${SONAR_TOKEN}:" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            --data-urlencode "projectKey=${SONAR_PROJECT_KEY}" \
+            --data-urlencode "enable=false" \
+            "https://sonarcloud.io/api/autoscan/activation")
+          if [ "${http_code}" -ge 400 ]; then
+            echo "Unable to disable SonarCloud automatic analysis (HTTP ${http_code})."
+            cat autoscan_response.json
+            exit 1
+          fi
+
       - name: Build Sonar arguments
         if: steps.sonar_config.outputs.enabled == 'true'
         id: sonar_args

--- a/docs/operations/CI_SECRETS.md
+++ b/docs/operations/CI_SECRETS.md
@@ -5,6 +5,7 @@ This file documents repository-level secrets and variables used by GitHub Action
 ## Required for Core CI
 - `SONAR_TOKEN`: token for SonarQube/SonarCloud scan upload.
 - `SONAR_PROJECT_KEY` (repository variable): project key used by Sonar scanner.
+- `SONAR_ORGANIZATION` (repository variable): required when using SonarCloud.
 - `CODECOV_TOKEN` (optional): enables Codecov coverage upload if configured.
 
 ## Required for Docker Image Publishing
@@ -21,7 +22,6 @@ If Docker Hub credentials are not set, workflows still publish to GHCR where con
 When these are missing, `.github/workflows/vercel.yml` exits cleanly with a skip message.
 
 ## Optional Sonar Variables
-- `SONAR_ORGANIZATION` (for SonarCloud)
 - `SONAR_HOST_URL` (secret, for self-hosted SonarQube; defaults to `https://sonarcloud.io` when not set)
 - `SONAR_BRANCH`, `SONAR_SEVERITIES`, `SONAR_STATUSES`, `SONAR_MAX_CREATE`, `SONAR_LABEL`, `SONAR_AUTO_CLOSE` (used by Sonar issues sync workflow)
 

--- a/docs/operations/SONARQUBE.md
+++ b/docs/operations/SONARQUBE.md
@@ -10,10 +10,14 @@ This repository uses `.github/workflows/sonar.yml` for optional Sonar analysis.
 ## Required Configuration
 - Secret: `SONAR_TOKEN`
 - Variable: `SONAR_PROJECT_KEY`
+- Variable: `SONAR_ORGANIZATION` (required when using SonarCloud host)
 
 ## Optional Configuration
-- Variable: `SONAR_ORGANIZATION` (required for SonarCloud org mapping)
 - Secret: `SONAR_HOST_URL` (set for self-hosted SonarQube; defaults to SonarCloud URL if absent)
+
+## SonarCloud Note
+- The workflow disables SonarCloud Automatic Analysis via API before CI scan.
+- `SONAR_TOKEN` must have permission to administer the SonarCloud project.
 
 ## Sonar Issue Sync
 - `.github/workflows/sonar_issues_sync.yml` syncs Sonar issues into GitHub issues.


### PR DESCRIPTION
## Summary
- set SONAR_ORGANIZATION at repo level (already configured)
- update Sonar workflow to disable SonarCloud Automatic Analysis via API before scanner run
- keep self-hosted SonarQube flow unchanged (SONAR_HOST_URL path)
- update Sonar operations docs and CI secrets docs

## Why
The SonarCloud scan failed with: You are running CI analysis while Automatic Analysis is enabled.
This change resolves that conflict for real SonarCloud CI analysis.

## Validation
- workflow YAML parses successfully
- SonarCloud run previously reached scanner and failed only on autoscan conflict
- new step calls /api/autoscan/activation with enable=false before scan