### PR TITLE
fix: close remaining CodeQL stack-trace/SSRF alert paths

### DIFF
--- a/apps/api/app/api/routes/auto_outreach.py
+++ b/apps/api/app/api/routes/auto_outreach.py
@@ -48,10 +48,10 @@ def create_campaign(
         )
         return result
     except ValueError as e:
-        log.warning("create_campaign_invalid", error=str(e))
+        log.warning("create_campaign_invalid", error_type=type(e).__name__)
         raise HTTPException(status_code=400, detail="Invalid request")
     except Exception as e:
-        log.error("create_campaign_failed", error=str(e))
+        log.error("create_campaign_failed", error_type=type(e).__name__)
         raise HTTPException(status_code=500, detail="Campaign creation failed")
 
 
@@ -73,7 +73,7 @@ def get_suggestions(
         )
         return suggestions
     except Exception as e:
-        log.error("get_suggestions_failed", error=str(e))
+        log.error("get_suggestions_failed", error_type=type(e).__name__)
         raise HTTPException(
             status_code=500, detail="Failed to get outreach suggestions"
         )
@@ -97,7 +97,7 @@ def get_entity_status(
         )
         return status
     except Exception as e:
-        log.error("get_entity_status_failed", error=str(e))
+        log.error("get_entity_status_failed", error_type=type(e).__name__)
         raise HTTPException(
             status_code=500, detail="Failed to get entity outreach status"
         )

--- a/apps/api/app/api/routes/data_health.py
+++ b/apps/api/app/api/routes/data_health.py
@@ -32,27 +32,6 @@ def _sanitize_errors(errors: list[str] | None) -> list[str]:
     return ["Pipeline operation failed"] * len(errors)
 
 
-def _sanitize_result_payload(payload: object) -> object:
-    """Recursively redact exception-like fields from pipeline payloads."""
-    if isinstance(payload, dict):
-        sanitized: dict[str, object] = {}
-        for key, value in payload.items():
-            lowered = key.lower()
-            if lowered in {"error", "errors", "exception", "traceback"}:
-                if isinstance(value, list):
-                    sanitized[key] = _sanitize_errors([str(v) for v in value])
-                elif value is None:
-                    sanitized[key] = None
-                else:
-                    sanitized[key] = "Pipeline operation failed"
-                continue
-            sanitized[key] = _sanitize_result_payload(value)
-        return sanitized
-    if isinstance(payload, list):
-        return [_sanitize_result_payload(item) for item in payload]
-    return payload
-
-
 @router.get("/status")
 def data_health_status(
     db: Annotated[Session, Depends(get_db)],
@@ -152,7 +131,7 @@ def trigger_market_refresh(
         return {
             "status": result["status"],
             "duration_seconds": result["duration_seconds"],
-            "results": _sanitize_result_payload(result.get("results", {})),
+            "sources": sorted((result.get("results") or {}).keys()),
             "errors": _sanitize_errors(result.get("errors")),
         }
     finally:
@@ -176,7 +155,7 @@ def trigger_intelligence_refresh(
         return {
             "status": result["status"],
             "duration_seconds": result["duration_seconds"],
-            "results": _sanitize_result_payload(result.get("results", {})),
+            "sources": sorted((result.get("results") or {}).keys()),
             "errors": _sanitize_errors(result.get("errors")),
         }
     finally:

--- a/apps/api/app/api/routes/enrich.py
+++ b/apps/api/app/api/routes/enrich.py
@@ -31,9 +31,7 @@ def enrich(
     _: Annotated[None, Depends(require_role("admin", "analyst"))],
 ):
     if entity_type not in ("cooperative", "roaster"):
-        raise HTTPException(
-            status_code=400, detail=f"Invalid entity_type: {entity_type}"
-        )
+        raise HTTPException(status_code=400, detail="Invalid entity_type")
     try:
         out = enrich_entity(
             db,
@@ -46,7 +44,7 @@ def enrich(
     except ValueError as e:
         log.warning(
             "enrich_request_invalid",
-            error=str(e),
+            error_type=type(e).__name__,
             entity_type=entity_type,
             entity_id=entity_id,
         )

--- a/apps/api/app/services/enrichment.py
+++ b/apps/api/app/services/enrichment.py
@@ -183,9 +183,8 @@ def fetch_text(url: str, timeout_seconds: int = 25) -> tuple[str, dict[str, Any]
             # Re-apply URL sanitizer in the same control flow right before the sink
             # so static analysis can prove SSRF protection.
             safe_request_url = _validate_public_http_url(current_url)
-            r = client.get(
-                safe_request_url
-            )  # codeql[py/full-ssrf] NOSONAR: URL validated via strict allowlist, port, and IP checks
+            # codeql[py/full-ssrf]
+            r = client.get(safe_request_url)  # NOSONAR: URL is strictly validated
             # If this is not a redirect, stop here.
             if r.status_code not in {301, 302, 303, 307, 308}:
                 break

--- a/apps/api/tests/test_data_health_api.py
+++ b/apps/api/tests/test_data_health_api.py
@@ -88,11 +88,7 @@ def test_refresh_market_redacts_internal_errors(client, auth_headers, monkeypatc
     payload = response.json()
     assert payload["status"] == "partial"
     assert payload["errors"] == ["Pipeline operation failed"]
-    assert payload["results"]["fx_rates"]["error"] == "Pipeline operation failed"
-    assert payload["results"]["fx_rates"]["errors"] == [
-        "Pipeline operation failed",
-        "Pipeline operation failed",
-    ]
+    assert payload["sources"] == ["fx_rates"]
 
 
 def test_refresh_intelligence_redacts_internal_errors(
@@ -106,8 +102,7 @@ def test_refresh_intelligence_redacts_internal_errors(
     payload = response.json()
     assert payload["status"] == "partial"
     assert payload["errors"] == ["Pipeline operation failed"]
-    assert payload["results"]["news"]["exception"] == "Pipeline operation failed"
-    assert payload["results"]["news"]["traceback"] == "Pipeline operation failed"
+    assert payload["sources"] == ["news"]
 
 
 def test_refresh_all_redacts_top_level_errors(client, auth_headers, monkeypatch):


### PR DESCRIPTION
## Summary
- harden route error handling to avoid exposing raw exception details in logs/responses
- simplify data-health refresh responses to return source keys only (no provider payload details)
- tighten CodeQL suppression placement for the SSRF-guarded outbound request
- adjust tests for the updated data-health response contract

## Validation
- `ruff format app tests`
- `ruff check app tests`
- `mypy --config-file ../../mypy.ini app`
- `pytest tests/test_data_health_api.py tests/test_enrich_api.py tests/test_auto_outreach.py tests/test_enrichment_security.py tests/test_peru_sourcing_intel_service.py -q`
- `pytest tests -q --cov=app --cov-report=xml:coverage.xml --cov-fail-under=0`