### PR TITLE
fix: sanitize remaining route exception flows for CodeQL

### DIFF
--- a/apps/api/app/api/routes/auto_outreach.py
+++ b/apps/api/app/api/routes/auto_outreach.py
@@ -47,11 +47,11 @@ def create_campaign(
             refine_with_llm=payload.refine_with_llm,
         )
         return result
-    except ValueError as e:
-        log.warning("create_campaign_invalid", error_type=type(e).__name__)
+    except ValueError:
+        log.warning("create_campaign_invalid")
         raise HTTPException(status_code=400, detail="Invalid request") from None
-    except Exception as e:
-        log.error("create_campaign_failed", error_type=type(e).__name__)
+    except Exception:
+        log.error("create_campaign_failed")
         raise HTTPException(
             status_code=500, detail="Campaign creation failed"
         ) from None
@@ -74,8 +74,8 @@ def get_suggestions(
             db, entity_type=entity_type, limit=limit
         )
         return suggestions
-    except Exception as e:
-        log.error("get_suggestions_failed", error_type=type(e).__name__)
+    except Exception:
+        log.error("get_suggestions_failed")
         raise HTTPException(
             status_code=500, detail="Failed to get outreach suggestions"
         ) from None
@@ -98,8 +98,8 @@ def get_entity_status(
             db, entity_type=entity_type, entity_id=entity_id
         )
         return status
-    except Exception as e:
-        log.error("get_entity_status_failed", error_type=type(e).__name__)
+    except Exception:
+        log.error("get_entity_status_failed")
         raise HTTPException(
             status_code=500, detail="Failed to get entity outreach status"
         ) from None

--- a/apps/api/app/api/routes/data_health.py
+++ b/apps/api/app/api/routes/data_health.py
@@ -7,7 +7,7 @@ and manual pipeline triggers.
 from typing import Annotated
 from time import perf_counter
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 import redis
 from sqlalchemy.orm import Session
 
@@ -137,6 +137,8 @@ def trigger_market_refresh(
             "sources": [],
             "errors": [],
         }
+    except Exception:
+        raise HTTPException(status_code=500, detail="Market refresh failed") from None
     finally:
         redis_client.close()
 
@@ -163,6 +165,10 @@ def trigger_intelligence_refresh(
             "sources": [],
             "errors": [],
         }
+    except Exception:
+        raise HTTPException(
+            status_code=500, detail="Intelligence refresh failed"
+        ) from None
     finally:
         redis_client.close()
 

--- a/apps/api/app/api/routes/enrich.py
+++ b/apps/api/app/api/routes/enrich.py
@@ -41,20 +41,18 @@ def enrich(
             use_llm=payload.use_llm,
         )
         return out
-    except ValueError as e:
+    except ValueError:
         log.warning(
             "enrich_request_invalid",
-            error_type=type(e).__name__,
             entity_type=entity_type,
             entity_id=entity_id,
         )
         raise HTTPException(
             status_code=400, detail="Invalid enrichment request"
         ) from None
-    except Exception as e:
+    except Exception:
         log.error(
             "enrich_request_failed",
-            error_type=type(e).__name__,
             entity_type=entity_type,
             entity_id=entity_id,
         )

--- a/apps/api/tests/test_data_health_api.py
+++ b/apps/api/tests/test_data_health_api.py
@@ -113,6 +113,36 @@ def test_refresh_intelligence_redacts_internal_errors(
     assert payload["sources"] == []
 
 
+def test_refresh_market_runtime_error_returns_500(client, auth_headers, monkeypatch):
+    _patch_data_health_deps(monkeypatch)
+    monkeypatch.setattr(
+        _DummyOrchestrator,
+        "run_market_pipeline",
+        lambda self: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    response = client.post("/data-health/refresh-market", headers=auth_headers)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Market refresh failed"
+
+
+def test_refresh_intelligence_runtime_error_returns_500(
+    client, auth_headers, monkeypatch
+):
+    _patch_data_health_deps(monkeypatch)
+    monkeypatch.setattr(
+        _DummyOrchestrator,
+        "run_intelligence_pipeline",
+        lambda self: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    response = client.post("/data-health/refresh-intelligence", headers=auth_headers)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Intelligence refresh failed"
+
+
 def test_refresh_all_redacts_top_level_errors(client, auth_headers, monkeypatch):
     _patch_data_health_deps(monkeypatch)
 


### PR DESCRIPTION
## Summary
- remove exception object propagation (`as e`) from API route handlers still flagged by stack-trace exposure checks
- add explicit sanitized `HTTPException(500)` handling for data-health refresh endpoints
- expand data-health tests for refresh failure branches

## Validation
- `ruff format app tests`
- `ruff check app tests`
- `mypy --config-file ../../mypy.ini app`
- `pytest tests/test_data_health_api.py tests/test_auto_outreach_api.py tests/test_enrich_api.py tests/test_auto_outreach.py tests/test_enrichment_security.py -q`
- `pytest tests -q --cov=app --cov-report=xml:coverage.xml --cov-fail-under=0`