### PR TITLE
chore: harden v0 delivery flow and fix Vercel output directory mismatch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Global owner fallback
+* @fx96515-hue
+
+# Frontend + deployment surfaces
+/apps/web/ @fx96515-hue
+/vercel.json @fx96515-hue
+/apps/web/vercel.json @fx96515-hue
+/.github/workflows/ @fx96515-hue

--- a/.github/workflows/v0-safety-gate.yml
+++ b/.github/workflows/v0-safety-gate.yml
@@ -1,0 +1,88 @@
+name: V0 Safety Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]
+
+jobs:
+  v0-guard:
+    name: V0 PR Guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Validate v0 PR boundaries
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.notice("No pull request payload. Nothing to validate.");
+              return;
+            }
+
+            const headRef = pr.head.ref;
+            const baseRef = pr.base.ref;
+            const labels = (pr.labels || []).map((l) => String(l.name || "").toLowerCase());
+
+            const isV0Branch = /^v0([/-]|$)/i.test(headRef) || /^ui\/v0-/i.test(headRef);
+            const isV0Label = labels.includes("v0");
+            const isV0Pr = isV0Branch || isV0Label;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const changedFiles = files.map((f) => f.filename);
+            const allowedPrefixes = [
+              "apps/web/",
+              "docs/ui/",
+              ".github/workflows/vercel.yml",
+              ".github/workflows/v0-safety-gate.yml",
+              ".github/CODEOWNERS",
+              "vercel.json",
+              "apps/web/vercel.json",
+              "README.md",
+            ];
+
+            const outOfScope = changedFiles.filter(
+              (f) => !allowedPrefixes.some((allowed) => f === allowed || f.startsWith(allowed))
+            );
+
+            if (isV0Branch && baseRef === "main") {
+              core.setFailed(
+                "Direct v0-* branches into main are blocked. Use ui/v0-sandbox first, then a reviewed follow-up PR to main."
+              );
+              return;
+            }
+
+            if (!isV0Pr) {
+              core.notice("Non-v0 PR detected; safety guard passed.");
+              return;
+            }
+
+            if (baseRef !== "ui/v0-sandbox") {
+              core.setFailed(
+                `v0 PRs must target ui/v0-sandbox. Current base is '${baseRef}'.`
+              );
+              return;
+            }
+
+            if (outOfScope.length > 0) {
+              core.setFailed(
+                [
+                  "v0 PR changes are out of allowed scope.",
+                  "Allowed scope: apps/web/, docs/ui/, Vercel workflow/config files.",
+                  "Out-of-scope files:",
+                  ...outOfScope.map((f) => `- ${f}`),
+                ].join("\n")
+              );
+              return;
+            }
+
+            core.notice("v0 safety guard passed.");

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "npm ci --no-audit --no-fund",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}

--- a/docs/operations/V0_SAFE_DELIVERY.md
+++ b/docs/operations/V0_SAFE_DELIVERY.md
@@ -1,0 +1,44 @@
+# V0 Safe Delivery Flow
+
+This repository uses a two-step delivery path for `v0` generated UI changes to avoid destabilizing `main`.
+
+## Branch model
+
+1. `ui/v0-sandbox`
+2. reviewed feature branch (optional)
+3. `main`
+
+`v0` output must land in `ui/v0-sandbox` first. A follow-up PR then promotes approved changes to `main`.
+
+## Guard rails
+
+- `.github/workflows/v0-safety-gate.yml` blocks:
+  - direct `v0-*` PRs to `main`
+  - `v0` PRs that target anything except `ui/v0-sandbox`
+  - `v0` PRs that modify files outside frontend/deploy scope
+- `.github/CODEOWNERS` enforces code-owner review on UI/deploy files.
+- Branch protection on `main` requires PR-based delivery.
+
+## Allowed v0 scope
+
+- `apps/web/**`
+- `docs/ui/**`
+- `vercel.json`
+- `apps/web/vercel.json`
+- `.github/workflows/vercel.yml`
+- `.github/workflows/v0-safety-gate.yml`
+- `.github/CODEOWNERS`
+- `README.md`
+
+## Vercel build stability
+
+To avoid default static-output assumptions (for example expecting `public/`), this repo pins build settings in:
+
+- `/vercel.json` (repo-root deployment case)
+- `/apps/web/vercel.json` (app-root deployment case)
+
+Both files define:
+
+- `framework: nextjs`
+- explicit install/build commands
+- explicit output directory for Next.js build artifacts

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "npm ci --prefix apps/web --no-audit --no-fund",
+  "buildCommand": "npm run build --prefix apps/web",
+  "outputDirectory": "apps/web/.next"
+}


### PR DESCRIPTION
## What this changes
- add root-level `vercel.json` for monorepo/root deployments (`apps/web` build/output)
- add `apps/web/vercel.json` for app-root deployments
- add `.github/workflows/v0-safety-gate.yml` to enforce safe v0 PR boundaries
- add `.github/CODEOWNERS` so UI/deploy surfaces require owner review
- add runbook: `docs/operations/V0_SAFE_DELIVERY.md`

## Why
Vercel deployments were failing with:
`No Output Directory named public found`.
This PR pins the build/output config so Vercel no longer assumes a static `public/` output.

It also prevents v0-generated UI changes from accidentally touching backend/infra or going directly to `main`.

## Verified locally
- `npm run lint` (apps/web) ✅
- `npm run build` (apps/web) ✅
- `npm run test:ui` (apps/web) ✅

## Infra changes already applied
- created branch `ui/v0-sandbox`
- enabled branch protection on `main` (PR + review + CODEOWNERS + linear history + no force push)
- created repo label `v0`