### PR TITLE
fix(api): reduce sonar debt in shipment/lot/roaster route cluster

### DIFF
--- a/apps/api/app/api/routes/knowledge_graph.py
+++ b/apps/api/app/api/routes/knowledge_graph.py
@@ -186,7 +186,7 @@ def get_path_by_node_ids(
 def get_hidden_connections(
     entity_type: str,
     entity_id: str,  # Accept str to handle both numeric IDs and string-based IDs
-    max_hops: int = Query(3, ge=2, le=5, description="Maximum hops to search"),
+    max_hops: Annotated[int, Query(ge=2, le=5, description="Maximum hops to search")] = 3,
     *,
     db: Annotated[Session, Depends(get_db)],
     _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],

--- a/apps/api/app/api/routes/logistics.py
+++ b/apps/api/app/api/routes/logistics.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -13,7 +15,7 @@ router = APIRouter()
 @router.post("/landed-cost", response_model=LandedCostResponse)
 def landed_cost(
     payload: LandedCostRequest,
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     return calc_landed_cost(db, **payload.model_dump())

--- a/apps/api/app/api/routes/lots.py
+++ b/apps/api/app/api/routes/lots.py
@@ -1,28 +1,38 @@
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy.orm import Session
 
 from app.api.deps import require_role
 from app.api.response_utils import apply_create_status
+from app.core.audit import AuditLogger
+from app.core.versioning import capture_entity_version
 from app.db.session import get_db
 from app.models.lot import Lot
 from app.models.user import User
 from app.schemas.lot import LotCreate, LotOut, LotUpdate
-from app.core.audit import AuditLogger
-from app.core.versioning import capture_entity_version
 from app.services.data_quality import recompute_entity_flags, resolve_entity_flags
 
 router = APIRouter()
+NOT_FOUND_DETAIL = "Not found"
+NOT_FOUND_RESPONSE: dict[int | str, dict[str, Any]] = {
+    404: {"description": NOT_FOUND_DETAIL}
+}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 @router.get("/", response_model=list[LotOut])
 def list_lots(
     cooperative_id: int | None = None,
-    include_deleted: bool = Query(False),
-    limit: int = Query(200, ge=1, le=500),
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    include_deleted: Annotated[bool, Query()] = False,
+    limit: Annotated[int, Query(ge=1, le=500)] = 200,
+    *,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     q = db.query(Lot)
     if not include_deleted:
@@ -37,8 +47,8 @@ def create_lot(
     payload: LotCreate,
     request: Request,
     response: Response,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin", "analyst")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin", "analyst"))],
 ):
     lot = Lot(**payload.model_dump())
     db.add(lot)
@@ -74,32 +84,33 @@ def create_lot(
     return lot
 
 
-@router.get("/{lot_id}", response_model=LotOut)
+@router.get("/{lot_id}", response_model=LotOut, responses=NOT_FOUND_RESPONSE)
 def get_lot(
     lot_id: int,
-    include_deleted: bool = Query(False),
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    include_deleted: Annotated[bool, Query()] = False,
+    *,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     q = db.query(Lot).filter(Lot.id == lot_id)
     if not include_deleted:
         q = q.filter(Lot.deleted_at.is_(None))
     lot = q.first()
     if not lot:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
     return lot
 
 
-@router.patch("/{lot_id}", response_model=LotOut)
+@router.patch("/{lot_id}", response_model=LotOut, responses=NOT_FOUND_RESPONSE)
 def update_lot(
     lot_id: int,
     payload: LotUpdate,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin", "analyst")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin", "analyst"))],
 ):
     lot = db.query(Lot).filter(Lot.id == lot_id, Lot.deleted_at.is_(None)).first()
     if not lot:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     # Capture old data for audit log
     old_data = {
@@ -139,15 +150,15 @@ def update_lot(
     return lot
 
 
-@router.delete("/{lot_id}")
+@router.delete("/{lot_id}", responses=NOT_FOUND_RESPONSE)
 def delete_lot(
     lot_id: int,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin"))],
 ):
     lot = db.query(Lot).filter(Lot.id == lot_id).first()
     if not lot:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     # Capture data before deletion for audit log
     entity_data = {
@@ -156,7 +167,7 @@ def delete_lot(
         "weight_kg": lot.weight_kg,
     }
 
-    lot.deleted_at = datetime.utcnow()
+    lot.deleted_at = _utcnow()
     db.commit()
 
     # Log deletion for audit trail
@@ -181,15 +192,15 @@ def delete_lot(
     return {"status": "deleted"}
 
 
-@router.post("/{lot_id}/restore")
+@router.post("/{lot_id}/restore", responses=NOT_FOUND_RESPONSE)
 def restore_lot(
     lot_id: int,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin"))],
 ):
     lot = db.query(Lot).filter(Lot.id == lot_id).first()
     if not lot:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     lot.deleted_at = None
     db.commit()

--- a/apps/api/app/api/routes/regions.py
+++ b/apps/api/app/api/routes/regions.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
@@ -15,9 +17,10 @@ router = APIRouter()
 @router.get("/", response_model=list[RegionOut])
 def list_regions(
     country: str | None = None,
-    limit: int = Query(500, ge=1, le=2000),
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    limit: Annotated[int, Query(ge=1, le=2000)] = 500,
+    *,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     q = db.query(Region)
     if country:
@@ -29,11 +32,15 @@ def list_regions(
 
 @router.get("/peru", response_model=list[PeruRegionOut])
 def list_peru_regions(
-    db: Session = Depends(get_db), _=Depends(require_role("admin", "analyst", "viewer"))
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     return db.query(PeruRegion).order_by(PeruRegion.name.asc()).all()
 
 
 @router.post("/peru/seed")
-def seed(db: Session = Depends(get_db), _=Depends(require_role("admin", "analyst"))):
+def seed(
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst"))],
+):
     return seed_default_regions(db)

--- a/apps/api/app/api/routes/roasters.py
+++ b/apps/api/app/api/routes/roasters.py
@@ -1,6 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
@@ -17,13 +18,22 @@ from app.services.data_quality import recompute_entity_flags, resolve_entity_fla
 from app.core.config import settings
 
 router = APIRouter()
+NOT_FOUND_DETAIL = "Not found"
+NOT_FOUND_RESPONSE: dict[int | str, dict[str, Any]] = {
+    404: {"description": NOT_FOUND_DETAIL}
+}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 @router.get("/", response_model=list[RoasterOut])
 def list_roasters(
-    include_deleted: bool = Query(False),
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    include_deleted: Annotated[bool, Query()] = False,
+    *,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     q = db.query(Roaster)
     if not include_deleted:
@@ -36,8 +46,8 @@ def create_roaster(
     payload: RoasterCreate,
     request: Request,
     response: Response,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin", "analyst")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin", "analyst"))],
 ):
     r = Roaster(**payload.model_dump())
     db.add(r)
@@ -83,28 +93,29 @@ def create_roaster(
     return r
 
 
-@router.get("/{roaster_id}", response_model=RoasterOut)
+@router.get("/{roaster_id}", response_model=RoasterOut, responses=NOT_FOUND_RESPONSE)
 def get_roaster(
     roaster_id: int,
-    include_deleted: bool = Query(False),
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    include_deleted: Annotated[bool, Query()] = False,
+    *,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     q = db.query(Roaster).filter(Roaster.id == roaster_id)
     if not include_deleted:
         q = q.filter(Roaster.deleted_at.is_(None))
     r = q.first()
     if not r:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
     return r
 
 
-@router.patch("/{roaster_id}", response_model=RoasterOut)
+@router.patch("/{roaster_id}", response_model=RoasterOut, responses=NOT_FOUND_RESPONSE)
 def update_roaster(
     roaster_id: int,
     payload: RoasterUpdate,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin", "analyst")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin", "analyst"))],
 ):
     r = (
         db.query(Roaster)
@@ -112,7 +123,7 @@ def update_roaster(
         .first()
     )
     if not r:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     # Capture old data for audit log
     old_data = {k: getattr(r, k) for k in payload.model_dump(exclude_unset=True).keys()}
@@ -160,15 +171,15 @@ def update_roaster(
     return r
 
 
-@router.delete("/{roaster_id}")
+@router.delete("/{roaster_id}", responses=NOT_FOUND_RESPONSE)
 def delete_roaster(
     roaster_id: int,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin"))],
 ):
     r = db.query(Roaster).filter(Roaster.id == roaster_id).first()
     if not r:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     # Capture data before deletion for audit log
     entity_data = {
@@ -177,7 +188,7 @@ def delete_roaster(
         "website": r.website,
     }
 
-    r.deleted_at = datetime.utcnow()
+    r.deleted_at = _utcnow()
     db.commit()
 
     # Log deletion for audit trail
@@ -206,15 +217,15 @@ def delete_roaster(
     return {"status": "deleted"}
 
 
-@router.post("/{roaster_id}/restore")
+@router.post("/{roaster_id}/restore", responses=NOT_FOUND_RESPONSE)
 def restore_roaster(
     roaster_id: int,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin"))],
 ):
     r = db.query(Roaster).filter(Roaster.id == roaster_id).first()
     if not r:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     r.deleted_at = None
     db.commit()
@@ -249,9 +260,10 @@ def restore_roaster(
 
 @router.get("/export/csv", response_class=StreamingResponse)
 def export_roasters_csv(
-    include_deleted: bool = Query(False),
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    include_deleted: Annotated[bool, Query()] = False,
+    *,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     """Export all roasters to CSV format."""
     q = db.query(Roaster)

--- a/apps/api/app/api/routes/shipments.py
+++ b/apps/api/app/api/routes/shipments.py
@@ -1,7 +1,8 @@
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy.orm import Session
-from datetime import datetime
-from typing import Any
 
 from app.api.deps import require_role
 from app.api.response_utils import apply_create_status
@@ -28,6 +29,15 @@ SHIPMENT_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
     404: {"description": "Shipment not found"},
     422: {"description": "Invalid datetime format"},
 }
+NOT_FOUND_DETAIL = "Not found"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utcnow_iso() -> str:
+    return _utcnow().isoformat()
 
 
 def _parse_iso_datetime_or_422(value: str, field_name: str) -> datetime:
@@ -38,6 +48,90 @@ def _parse_iso_datetime_or_422(value: str, field_name: str) -> datetime:
             status_code=422,
             detail=f"Invalid ISO-8601 datetime for '{field_name}'",
         ) from exc
+
+
+def _ensure_unique_identifiers(db: Session, payload: ShipmentCreate) -> None:
+    checks = (
+        ("container_number", payload.container_number, "Container number already exists"),
+        ("bill_of_lading", payload.bill_of_lading, "Bill of lading already exists"),
+    )
+    for column_name, value, error_message in checks:
+        existing = (
+            db.query(Shipment)
+            .filter(
+                getattr(Shipment, column_name) == value,
+                Shipment.deleted_at.is_(None),
+            )
+            .first()
+        )
+        if existing:
+            raise HTTPException(status_code=400, detail=error_message)
+
+
+def _apply_create_datetime_fields(shipment: Shipment, payload: ShipmentCreate) -> None:
+    if payload.departure_at and not payload.departure_date:
+        shipment.departure_date = payload.departure_at.isoformat()
+    if payload.estimated_arrival_at and not payload.estimated_arrival:
+        shipment.estimated_arrival = payload.estimated_arrival_at.isoformat()
+    if payload.actual_arrival_at and not payload.actual_arrival:
+        shipment.actual_arrival = payload.actual_arrival_at.isoformat()
+
+    if payload.departure_at is None and payload.departure_date:
+        shipment.departure_at = _parse_iso_datetime_or_422(
+            payload.departure_date, "departure_date"
+        )
+    if payload.estimated_arrival_at is None and payload.estimated_arrival:
+        shipment.estimated_arrival_at = _parse_iso_datetime_or_422(
+            payload.estimated_arrival, "estimated_arrival"
+        )
+    if payload.actual_arrival_at is None and payload.actual_arrival:
+        shipment.actual_arrival_at = _parse_iso_datetime_or_422(
+            payload.actual_arrival, "actual_arrival"
+        )
+
+
+def _dedupe_lot_ids(lot_ids: list[int] | None) -> list[int]:
+    if not lot_ids:
+        return []
+    return list(dict.fromkeys(lot_ids))
+
+
+def _resolve_create_lot_ids(payload: ShipmentCreate, shipment: Shipment) -> list[int]:
+    if payload.lot_ids:
+        lot_ids = _dedupe_lot_ids(payload.lot_ids)
+        if shipment.lot_id is None and lot_ids:
+            shipment.lot_id = lot_ids[0]
+        return lot_ids
+    if payload.lot_id:
+        return [payload.lot_id]
+    return []
+
+
+def _apply_update_datetime_fields(update_dict: dict[str, Any], current_status: str) -> None:
+    if "departure_at" in update_dict and update_dict.get("departure_at"):
+        update_dict.setdefault("departure_date", update_dict["departure_at"].isoformat())
+    if "estimated_arrival_at" in update_dict and update_dict.get("estimated_arrival_at"):
+        update_dict.setdefault(
+            "estimated_arrival", update_dict["estimated_arrival_at"].isoformat()
+        )
+    if "actual_arrival_at" in update_dict and update_dict.get("actual_arrival_at"):
+        update_dict.setdefault("actual_arrival", update_dict["actual_arrival_at"].isoformat())
+
+    if "departure_at" not in update_dict and "departure_date" in update_dict:
+        update_dict["departure_at"] = _parse_iso_datetime_or_422(
+            update_dict["departure_date"], "departure_date"
+        )
+    if "estimated_arrival_at" not in update_dict and "estimated_arrival" in update_dict:
+        update_dict["estimated_arrival_at"] = _parse_iso_datetime_or_422(
+            update_dict["estimated_arrival"], "estimated_arrival"
+        )
+    if "actual_arrival_at" not in update_dict and "actual_arrival" in update_dict:
+        update_dict["actual_arrival_at"] = _parse_iso_datetime_or_422(
+            update_dict["actual_arrival"], "actual_arrival"
+        )
+
+    if "status" in update_dict and update_dict["status"] != current_status:
+        update_dict["status_updated_at"] = _utcnow_iso()
 
 
 def _build_shipment_out(db: Session, shipment: Shipment) -> ShipmentOut:
@@ -73,10 +167,11 @@ def list_shipments(
     status: str | None = None,
     origin_port: str | None = None,
     destination_port: str | None = None,
-    include_deleted: bool = Query(False),
-    limit: int = Query(200, ge=1, le=500),
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    include_deleted: Annotated[bool, Query()] = False,
+    limit: Annotated[int, Query(ge=1, le=500)] = 200,
+    *,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     """List all shipments with optional filters."""
     q = db.query(Shipment)
@@ -94,8 +189,8 @@ def list_shipments(
 
 @router.get("/active", response_model=list[ShipmentOut])
 def list_active_shipments(
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     """Get active shipments (status=in_transit)."""
     shipments = (
@@ -109,8 +204,8 @@ def list_active_shipments(
 
 @router.get("/delayed", response_model=list[ShipmentOut])
 def list_delayed_shipments(
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     """Get delayed shipments (delay_hours > 0)."""
     shipments = (
@@ -132,8 +227,8 @@ def create_shipment(
     payload: ShipmentCreate,
     request: Request,
     response: Response,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin", "analyst")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin", "analyst"))],
 ):
     """Create a new shipment."""
     # Idempotent create: return existing shipment if both identifiers match.
@@ -150,55 +245,11 @@ def create_shipment(
         return existing
 
     # Otherwise, enforce uniqueness constraints.
-    existing_container = (
-        db.query(Shipment)
-        .filter(
-            Shipment.container_number == payload.container_number,
-            Shipment.deleted_at.is_(None),
-        )
-        .first()
-    )
-    if existing_container:
-        raise HTTPException(status_code=400, detail="Container number already exists")
-
-    existing_bol = (
-        db.query(Shipment)
-        .filter(
-            Shipment.bill_of_lading == payload.bill_of_lading,
-            Shipment.deleted_at.is_(None),
-        )
-        .first()
-    )
-    if existing_bol:
-        raise HTTPException(status_code=400, detail="Bill of lading already exists")
+    _ensure_unique_identifiers(db, payload)
 
     shipment = Shipment(**payload.model_dump(exclude={"lot_ids"}))
-    if payload.departure_at and not payload.departure_date:
-        shipment.departure_date = payload.departure_at.isoformat()
-    if payload.estimated_arrival_at and not payload.estimated_arrival:
-        shipment.estimated_arrival = payload.estimated_arrival_at.isoformat()
-    if payload.actual_arrival_at and not payload.actual_arrival:
-        shipment.actual_arrival = payload.actual_arrival_at.isoformat()
-
-    if payload.departure_at is None and payload.departure_date:
-        shipment.departure_at = _parse_iso_datetime_or_422(
-            payload.departure_date, "departure_date"
-        )
-    if payload.estimated_arrival_at is None and payload.estimated_arrival:
-        shipment.estimated_arrival_at = _parse_iso_datetime_or_422(
-            payload.estimated_arrival, "estimated_arrival"
-        )
-    if payload.actual_arrival_at is None and payload.actual_arrival:
-        shipment.actual_arrival_at = _parse_iso_datetime_or_422(
-            payload.actual_arrival, "actual_arrival"
-        )
-    lot_ids: list[int] = []
-    if payload.lot_ids:
-        lot_ids = list(dict.fromkeys(payload.lot_ids))
-        if shipment.lot_id is None and lot_ids:
-            shipment.lot_id = lot_ids[0]
-    elif payload.lot_id:
-        lot_ids = [payload.lot_id]
+    _apply_create_datetime_fields(shipment, payload)
+    lot_ids = _resolve_create_lot_ids(payload, shipment)
     shipment.tracking_events = []  # Initialize empty tracking events
     db.add(shipment)
     db.commit()
@@ -238,12 +289,17 @@ def create_shipment(
     return _build_shipment_out(db, shipment)
 
 
-@router.get("/{shipment_id}", response_model=ShipmentOut)
+@router.get(
+    "/{shipment_id}",
+    response_model=ShipmentOut,
+    responses=SHIPMENT_ERROR_RESPONSES,
+)
 def get_shipment(
     shipment_id: int,
-    include_deleted: bool = Query(False),
-    db: Session = Depends(get_db),
-    _=Depends(require_role("admin", "analyst", "viewer")),
+    include_deleted: Annotated[bool, Query()] = False,
+    *,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
 ):
     """Get shipment details."""
     q = db.query(Shipment).filter(Shipment.id == shipment_id)
@@ -251,7 +307,7 @@ def get_shipment(
         q = q.filter(Shipment.deleted_at.is_(None))
     shipment = q.first()
     if not shipment:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
     return _build_shipment_out(db, shipment)
 
 
@@ -263,8 +319,8 @@ def get_shipment(
 def update_shipment(
     shipment_id: int,
     payload: ShipmentUpdate,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin", "analyst")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin", "analyst"))],
 ):
     """Update shipment."""
     shipment = (
@@ -273,7 +329,7 @@ def update_shipment(
         .first()
     )
     if not shipment:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     # Capture old data for audit log
     old_data = {
@@ -282,34 +338,7 @@ def update_shipment(
 
     # Update status_updated_at if status is changing
     update_dict = payload.model_dump(exclude_unset=True, exclude={"lot_ids"})
-    if "departure_at" in update_dict and update_dict.get("departure_at"):
-        update_dict.setdefault(
-            "departure_date", update_dict["departure_at"].isoformat()
-        )
-    if "estimated_arrival_at" in update_dict and update_dict.get(
-        "estimated_arrival_at"
-    ):
-        update_dict.setdefault(
-            "estimated_arrival", update_dict["estimated_arrival_at"].isoformat()
-        )
-    if "actual_arrival_at" in update_dict and update_dict.get("actual_arrival_at"):
-        update_dict.setdefault(
-            "actual_arrival", update_dict["actual_arrival_at"].isoformat()
-        )
-    if "departure_at" not in update_dict and "departure_date" in update_dict:
-        update_dict["departure_at"] = _parse_iso_datetime_or_422(
-            update_dict["departure_date"], "departure_date"
-        )
-    if "estimated_arrival_at" not in update_dict and "estimated_arrival" in update_dict:
-        update_dict["estimated_arrival_at"] = _parse_iso_datetime_or_422(
-            update_dict["estimated_arrival"], "estimated_arrival"
-        )
-    if "actual_arrival_at" not in update_dict and "actual_arrival" in update_dict:
-        update_dict["actual_arrival_at"] = _parse_iso_datetime_or_422(
-            update_dict["actual_arrival"], "actual_arrival"
-        )
-    if "status" in update_dict and update_dict["status"] != shipment.status:
-        update_dict["status_updated_at"] = datetime.now().isoformat()
+    _apply_update_datetime_fields(update_dict, shipment.status)
 
     for k, v in update_dict.items():
         setattr(shipment, k, v)
@@ -318,7 +347,7 @@ def update_shipment(
 
     if payload.lot_ids is not None:
         db.query(ShipmentLot).filter(ShipmentLot.shipment_id == shipment_id).delete()
-        for lot_id in list(dict.fromkeys(payload.lot_ids)):
+        for lot_id in _dedupe_lot_ids(payload.lot_ids):
             db.add(ShipmentLot(shipment_id=shipment_id, lot_id=lot_id))
         shipment.lot_id = payload.lot_ids[0] if payload.lot_ids else None
         db.commit()
@@ -352,16 +381,16 @@ def update_shipment(
     return _build_shipment_out(db, shipment)
 
 
-@router.delete("/{shipment_id}")
+@router.delete("/{shipment_id}", responses=SHIPMENT_ERROR_RESPONSES)
 def delete_shipment(
     shipment_id: int,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin"))],
 ):
     """Delete shipment."""
     shipment = db.query(Shipment).filter(Shipment.id == shipment_id).first()
     if not shipment:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     # Capture data before deletion for audit log
     entity_data = {
@@ -370,7 +399,7 @@ def delete_shipment(
         "destination_port": shipment.destination_port,
     }
 
-    shipment.deleted_at = datetime.utcnow()
+    shipment.deleted_at = _utcnow()
     db.commit()
 
     # Log deletion for audit trail
@@ -399,15 +428,19 @@ def delete_shipment(
     return {"status": "deleted"}
 
 
-@router.post("/{shipment_id}/restore", response_model=ShipmentOut)
+@router.post(
+    "/{shipment_id}/restore",
+    response_model=ShipmentOut,
+    responses=SHIPMENT_ERROR_RESPONSES,
+)
 def restore_shipment(
     shipment_id: int,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin"))],
 ):
     shipment = db.query(Shipment).filter(Shipment.id == shipment_id).first()
     if not shipment:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     shipment.deleted_at = None
     db.commit()
@@ -448,8 +481,8 @@ def restore_shipment(
 def add_tracking_event(
     shipment_id: int,
     event: TrackingEventCreate,
-    db: Session = Depends(get_db),
-    user: User = Depends(require_role("admin", "analyst")),
+    db: Annotated[Session, Depends(get_db)],
+    user: Annotated[User, Depends(require_role("admin", "analyst"))],
 ):
     """Add a tracking event to a shipment."""
     shipment = (
@@ -458,7 +491,7 @@ def add_tracking_event(
         .first()
     )
     if not shipment:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     # Get existing tracking events or initialize
     # Defensive handling in case of unexpected data format
@@ -473,7 +506,7 @@ def add_tracking_event(
     tracking_events.append(new_event)
 
     # Force SQLAlchemy to detect the change by creating a new list
-    shipment.tracking_events = list(tracking_events)
+    shipment.tracking_events = tracking_events.copy()
 
     # Update current location
     shipment.current_location = event.location

--- a/apps/api/app/core/audit.py
+++ b/apps/api/app/core/audit.py
@@ -1,6 +1,6 @@
 """Audit logging for tracking all data modifications."""
 
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 from decimal import Decimal
 from typing import Any, Dict, Optional
 from uuid import UUID
@@ -13,6 +13,14 @@ from app.models.user import User
 from app.models.audit_log import AuditLog
 
 logger = structlog.get_logger(__name__)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utcnow_iso() -> str:
+    return _utcnow().isoformat()
 
 
 def _to_json_safe(value: Any) -> Any:
@@ -56,7 +64,7 @@ class AuditLogger:
                 entity_id=entity_id,
                 request_id=request_id,
                 payload=safe_payload,
-                created_at=datetime.utcnow(),
+                created_at=_utcnow(),
             )
             db.add(entry)
             db.commit()
@@ -82,7 +90,7 @@ class AuditLogger:
             entity_id=entity_id,
             entity_data=entity_data,
             request_id=request_id,
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=_utcnow_iso(),
         )
         AuditLogger._persist(
             db=db,
@@ -121,7 +129,7 @@ class AuditLogger:
             entity_id=entity_id,
             changes=changes,
             request_id=request_id,
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=_utcnow_iso(),
         )
         AuditLogger._persist(
             db=db,
@@ -152,7 +160,7 @@ class AuditLogger:
             entity_id=entity_id,
             entity_data=entity_data,
             request_id=request_id,
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=_utcnow_iso(),
         )
         AuditLogger._persist(
             db=db,
@@ -183,7 +191,7 @@ class AuditLogger:
             entity_id=entity_id,
             action=action,
             request_id=request_id,
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=_utcnow_iso(),
         )
         AuditLogger._persist(
             db=db,
@@ -215,7 +223,7 @@ class AuditLogger:
             success=success,
             reason=reason,
             request_id=request_id,
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=_utcnow_iso(),
         )
 
     @staticmethod
@@ -238,5 +246,5 @@ class AuditLogger:
             resource_id=resource_id,
             required_role=required_role,
             request_id=request_id,
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=_utcnow_iso(),
         )


### PR DESCRIPTION
## Summary
- migrated shipment/lot/roaster/regions/logistics route signatures to Annotated FastAPI style
- documented missing 404 responses on affected endpoints
- replaced remaining `datetime.utcnow()` hotpaths in route deletion flows and audit logging
- reduced shipment route complexity via helper extraction (`create`/`update` date handling and uniqueness checks)
- removed unnecessary `list()` clone in shipment tracking mutation path

## Validation
- `python -m ruff check app`
- `python -m mypy app`
- `python -m pytest -q tests/test_lots_api.py tests/test_roasters.py tests/test_shipments.py tests/test_regions_api.py tests/test_logistics_api.py tests/test_knowledge_graph.py tests/test_audit_logging.py`
