### PR TITLE
ci(sonar): focus gate on new-code critical/security and reduce sync noise

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -95,6 +95,12 @@ jobs:
           args="$args -Dsonar.sources=apps/api/app"
           args="$args -Dsonar.tests=apps/api/tests"
           args="$args -Dsonar.python.coverage.reportPaths=apps/api/coverage.xml"
+          args="$args -Dsonar.newCode.referenceBranch=main"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            args="$args -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}"
+            args="$args -Dsonar.pullrequest.branch=${{ github.head_ref }}"
+            args="$args -Dsonar.pullrequest.base=${{ github.base_ref }}"
+          fi
           if [ -n "${{ vars.SONAR_ORGANIZATION }}" ]; then
             args="$args -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}"
           fi
@@ -108,6 +114,17 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL != '' && secrets.SONAR_HOST_URL || 'https://sonarcloud.io' }}
         with:
           args: ${{ steps.sonar_args.outputs.args }}
+
+      - name: Enforce new-code gate (critical + vulnerabilities)
+        if: steps.sonar_config.outputs.enabled == 'true' && github.event_name == 'pull_request' && vars.SONAR_ENFORCE_NEW_CODE_GATE != 'false'
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL != '' && secrets.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+          SONAR_PULL_REQUEST: ${{ github.event.pull_request.number }}
+          SONAR_GATE_MAX_WAIT_SEC: ${{ vars.SONAR_GATE_MAX_WAIT_SEC != '' && vars.SONAR_GATE_MAX_WAIT_SEC || '180' }}
+          SONAR_GATE_POLL_INTERVAL_SEC: ${{ vars.SONAR_GATE_POLL_INTERVAL_SEC != '' && vars.SONAR_GATE_POLL_INTERVAL_SEC || '10' }}
+        run: python scripts/automation/sonar_enforce_new_code_gate.py
 
       - name: Explain why sonar is skipped
         if: steps.sonar_config.outputs.enabled != 'true'

--- a/.github/workflows/sonar_issues_sync.yml
+++ b/.github/workflows/sonar_issues_sync.yml
@@ -22,10 +22,15 @@ jobs:
         id: sonar_sync_config
         shell: bash
         run: |
-          if [ -n "${{ secrets.SONAR_TOKEN }}" ] && [ -n "${{ vars.SONAR_PROJECT_KEY }}" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ -z "${{ secrets.SONAR_TOKEN }}" ] || [ -z "${{ vars.SONAR_PROJECT_KEY }}" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "reason=missing SONAR_TOKEN or SONAR_PROJECT_KEY" >> "$GITHUB_OUTPUT"
+          elif [ "${{ vars.SONAR_ISSUE_SYNC_ENABLED }}" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "reason=SONAR_ISSUE_SYNC_ENABLED is not true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "reason=ok" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout
@@ -49,11 +54,11 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
           SONAR_BRANCH: ${{ vars.SONAR_BRANCH }}
-          SONAR_SEVERITIES: ${{ vars.SONAR_SEVERITIES }}
-          SONAR_STATUSES: ${{ vars.SONAR_STATUSES }}
-          SONAR_MAX_CREATE: ${{ vars.SONAR_MAX_CREATE }}
-          SONAR_LABEL: ${{ vars.SONAR_LABEL }}
-          SONAR_AUTO_CLOSE: ${{ vars.SONAR_AUTO_CLOSE }}
+          SONAR_SEVERITIES: ${{ vars.SONAR_SEVERITIES != '' && vars.SONAR_SEVERITIES || 'BLOCKER,CRITICAL' }}
+          SONAR_STATUSES: ${{ vars.SONAR_STATUSES != '' && vars.SONAR_STATUSES || 'OPEN,REOPENED' }}
+          SONAR_MAX_CREATE: ${{ vars.SONAR_MAX_CREATE != '' && vars.SONAR_MAX_CREATE || '5' }}
+          SONAR_LABEL: ${{ vars.SONAR_LABEL != '' && vars.SONAR_LABEL || 'sonarcloud' }}
+          SONAR_AUTO_CLOSE: ${{ vars.SONAR_AUTO_CLOSE != '' && vars.SONAR_AUTO_CLOSE || 'true' }}
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python scripts/automation/sonar_sync_issues.py
@@ -61,4 +66,4 @@ jobs:
       - name: Explain why sync is skipped
         if: steps.sonar_sync_config.outputs.enabled != 'true'
         run: |
-          echo "Skipping Sonar issue sync: missing SONAR_TOKEN or SONAR_PROJECT_KEY."
+          echo "Skipping Sonar issue sync: ${{ steps.sonar_sync_config.outputs.reason }}."

--- a/docs/operations/CI_SECRETS.md
+++ b/docs/operations/CI_SECRETS.md
@@ -23,7 +23,12 @@ When these are missing, `.github/workflows/vercel.yml` exits cleanly with a skip
 
 ## Optional Sonar Variables
 - `SONAR_HOST_URL` (secret, for self-hosted SonarQube; defaults to `https://sonarcloud.io` when not set)
-- `SONAR_BRANCH`, `SONAR_SEVERITIES`, `SONAR_STATUSES`, `SONAR_MAX_CREATE`, `SONAR_LABEL`, `SONAR_AUTO_CLOSE` (used by Sonar issues sync workflow)
+- `SONAR_ENFORCE_NEW_CODE_GATE` (default: enabled; set to `false` to disable PR new-code gate)
+- `SONAR_GATE_MAX_WAIT_SEC` (default: `180`)
+- `SONAR_GATE_POLL_INTERVAL_SEC` (default: `10`)
+- `SONAR_ISSUE_SYNC_ENABLED` (default: disabled; must be `true` to run issue sync)
+- `SONAR_BRANCH`, `SONAR_SEVERITIES`, `SONAR_STATUSES`, `SONAR_MAX_CREATE`, `SONAR_LABEL`, `SONAR_AUTO_CLOSE` (used by Sonar issue sync workflow)
+  - sync defaults if unset: `SONAR_SEVERITIES=BLOCKER,CRITICAL`, `SONAR_STATUSES=OPEN,REOPENED`, `SONAR_MAX_CREATE=5`, `SONAR_AUTO_CLOSE=true`
 
 ## Notes
 - Add secrets under: `Repository Settings -> Secrets and variables -> Actions`.

--- a/docs/operations/SONARQUBE.md
+++ b/docs/operations/SONARQUBE.md
@@ -6,6 +6,8 @@ This repository uses `.github/workflows/sonar.yml` for optional Sonar analysis.
 - Runs on `push` to `main`, PR updates, and manual dispatch.
 - Automatically skips (green) when required Sonar credentials are missing.
 - Runs API tests with coverage and uploads coverage-aware scan results.
+- Enforces a focused gate on PRs: fails only when **new code** introduces unresolved
+  `BLOCKER`/`CRITICAL` issues or `VULNERABILITY` findings.
 
 ## Required Configuration
 - Secret: `SONAR_TOKEN`
@@ -21,7 +23,12 @@ This repository uses `.github/workflows/sonar.yml` for optional Sonar analysis.
 
 ## Sonar Issue Sync
 - `.github/workflows/sonar_issues_sync.yml` syncs Sonar issues into GitHub issues.
-- It also skips cleanly when `SONAR_TOKEN` or `SONAR_PROJECT_KEY` is missing.
+- Sync is **disabled by default** and only runs when `SONAR_ISSUE_SYNC_ENABLED=true`.
+- Default sync behavior is intentionally conservative:
+  - severities: `BLOCKER,CRITICAL`
+  - statuses: `OPEN,REOPENED`
+  - max new issues per run: `5`
+  - auto-close resolved issues: enabled
 
 ## References
 - SonarCloud docs: https://sonarcloud.io/documentation

--- a/scripts/automation/sonar_enforce_new_code_gate.py
+++ b/scripts/automation/sonar_enforce_new_code_gate.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Fail CI when severe or security issues exist on Sonar new code."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+def _env(name: str, default: str = "") -> str:
+    return (os.getenv(name) or default).strip()
+
+
+def _int_env(name: str, default: int) -> int:
+    value = _env(name)
+    if not value:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _build_api_base() -> str:
+    explicit = _env("SONAR_API_BASE")
+    if explicit:
+        return explicit.rstrip("/")
+    host = _env("SONAR_HOST_URL", "https://sonarcloud.io").rstrip("/")
+    if host.endswith("/api"):
+        return host
+    return f"{host}/api"
+
+
+SONAR_API_BASE = _build_api_base()
+SONAR_TOKEN = _env("SONAR_TOKEN")
+SONAR_PROJECT_KEY = _env("SONAR_PROJECT_KEY")
+SONAR_BRANCH = _env("SONAR_BRANCH", "main")
+SONAR_PULL_REQUEST = _env("SONAR_PULL_REQUEST")
+
+CRITICAL_SEVERITIES = _env("SONAR_GATE_CRITICAL_SEVERITIES", "BLOCKER,CRITICAL")
+SECURITY_TYPES = _env("SONAR_GATE_SECURITY_TYPES", "VULNERABILITY")
+
+MAX_WAIT_SEC = _int_env("SONAR_GATE_MAX_WAIT_SEC", 180)
+POLL_INTERVAL_SEC = _int_env("SONAR_GATE_POLL_INTERVAL_SEC", 10)
+
+
+def _require_inputs() -> None:
+    missing: list[str] = []
+    if not SONAR_TOKEN:
+        missing.append("SONAR_TOKEN")
+    if not SONAR_PROJECT_KEY:
+        missing.append("SONAR_PROJECT_KEY")
+    if missing:
+        print(
+            "[warn] Sonar new-code gate skipped because required inputs are missing: "
+            + ", ".join(missing)
+        )
+        raise SystemExit(0)
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {SONAR_TOKEN}",
+        "Accept": "application/json",
+        "User-Agent": "coffeestudio-sonar-new-code-gate",
+    }
+
+
+def _http_json(url: str, *, retries: int = 4, timeout: int = 45) -> Any:
+    last_error: Exception | None = None
+    for attempt in range(1, retries + 1):
+        req = urllib.request.Request(url=url, headers=_headers(), method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            payload = exc.read().decode("utf-8", "replace")
+            is_retryable = exc.code in {408, 409, 425, 429, 500, 502, 503, 504}
+            if attempt < retries and is_retryable:
+                time.sleep(min(2**attempt, 8))
+                continue
+            raise RuntimeError(f"HTTP {exc.code} for {url}: {payload}") from exc
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            last_error = exc
+            if attempt < retries:
+                time.sleep(min(2**attempt, 8))
+                continue
+            break
+    raise RuntimeError(f"Failed to query Sonar API: {last_error}")
+
+
+def _base_issue_params() -> dict[str, str]:
+    params: dict[str, str] = {
+        "componentKeys": SONAR_PROJECT_KEY,
+        "resolved": "false",
+        "inNewCodePeriod": "true",
+        "ps": "1",
+    }
+    if SONAR_PULL_REQUEST:
+        params["pullRequest"] = SONAR_PULL_REQUEST
+    else:
+        params["branch"] = SONAR_BRANCH
+    return params
+
+
+def _query_issue_total(extra_params: dict[str, str]) -> int:
+    params = _base_issue_params()
+    params.update(extra_params)
+    url = f"{SONAR_API_BASE}/issues/search?{urllib.parse.urlencode(params)}"
+    data = _http_json(url)
+    total = data.get("total")
+    if isinstance(total, int):
+        return total
+    paging = data.get("paging", {})
+    if isinstance(paging, dict) and isinstance(paging.get("total"), int):
+        return int(paging["total"])
+    return 0
+
+
+def _scope_description() -> str:
+    if SONAR_PULL_REQUEST:
+        return f"pull request #{SONAR_PULL_REQUEST}"
+    return f"branch '{SONAR_BRANCH}'"
+
+
+def main() -> int:
+    _require_inputs()
+
+    deadline = time.time() + max(MAX_WAIT_SEC, 0)
+    last_error: Exception | None = None
+    critical_issues = 0
+    vulnerability_issues = 0
+
+    while True:
+        try:
+            critical_issues = _query_issue_total({"severities": CRITICAL_SEVERITIES})
+            vulnerability_issues = _query_issue_total({"types": SECURITY_TYPES})
+            last_error = None
+            break
+        except Exception as exc:  # pragma: no cover - network dependent
+            last_error = exc
+            if time.time() >= deadline:
+                break
+            print(f"[warn] Sonar gate query not ready yet: {exc}")
+            time.sleep(max(POLL_INTERVAL_SEC, 1))
+
+    if last_error is not None:
+        print(f"[error] Sonar new-code gate failed to query results: {last_error}")
+        return 1
+
+    print(
+        "[info] Sonar new-code gate scope=%s critical_issues=%d vulnerability_issues=%d"
+        % (_scope_description(), critical_issues, vulnerability_issues)
+    )
+
+    if critical_issues > 0 or vulnerability_issues > 0:
+        print(
+            "[error] Sonar gate failed: new code contains unresolved "
+            "BLOCKER/CRITICAL or security issues."
+        )
+        print(
+            "[hint] Inspect SonarCloud issues filtered by new code and fix before merge."
+        )
+        return 1
+
+    print("[ok] Sonar new-code gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/automation/sonar_sync_issues.py
+++ b/scripts/automation/sonar_sync_issues.py
@@ -16,11 +16,11 @@ SONAR_TOKEN = (os.getenv("SONAR_TOKEN") or "").strip()
 PROJECT_KEY = (os.getenv("SONAR_PROJECT_KEY") or "").strip()
 BRANCH = (os.getenv("SONAR_BRANCH") or "main").strip()
 
-SEVERITIES = (os.getenv("SONAR_SEVERITIES") or "").strip()
-STATUSES = (os.getenv("SONAR_STATUSES") or "OPEN,REOPENED,CONFIRMED").strip()
+SEVERITIES = (os.getenv("SONAR_SEVERITIES") or "BLOCKER,CRITICAL").strip()
+STATUSES = (os.getenv("SONAR_STATUSES") or "OPEN,REOPENED").strip()
 
-MAX_CREATE = int((os.getenv("SONAR_MAX_CREATE") or "30").strip())
-AUTO_CLOSE = (os.getenv("SONAR_AUTO_CLOSE") or "false").strip().lower() == "true"
+MAX_CREATE = int((os.getenv("SONAR_MAX_CREATE") or "5").strip())
+AUTO_CLOSE = (os.getenv("SONAR_AUTO_CLOSE") or "true").strip().lower() == "true"
 LABEL = (os.getenv("SONAR_LABEL") or "sonarcloud").strip()
 
 GH_TOKEN = (os.getenv("GITHUB_TOKEN") or "").strip()


### PR DESCRIPTION
## Summary
- keep Sonar enabled, but enforce a focused gate only on new PR code
- add a dedicated gate script that fails PRs only for unresolved BLOCKER/CRITICAL issues or VULNERABILITY findings
- set Sonar scanner args to use `main` as new-code reference branch and explicit PR metadata
- disable Sonar issue sync by default unless `SONAR_ISSUE_SYNC_ENABLED=true`
- throttle Sonar issue sync defaults to avoid GitHub issue flood (`BLOCKER,CRITICAL`, max `5`, auto-close on)
- document the new operational knobs in Sonar and CI secrets docs

## Validation
- python -m ruff check scripts/automation/sonar_enforce_new_code_gate.py scripts/automation/sonar_sync_issues.py
- python scripts/automation/sonar_enforce_new_code_gate.py
- workflow YAML parse sanity check for:
  - .github/workflows/sonar.yml
  - .github/workflows/sonar_issues_sync.yml