### PR TITLE
Fix monitoring issue hygiene: auto-close stale production alerts

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -274,9 +274,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            const apiStatus = "${{ steps.api_health.outputs.status }}";
             const shouldClose =
               "${{ steps.check_config.outputs.is_configured }}" !== "true" ||
-              "${{ steps.api_health.outputs.status }}" === "success";
+              apiStatus === "success" ||
+              apiStatus === "skipped";
             if (!shouldClose) {
               core.info("Keeping production-alert issues open because API is currently unhealthy.");
               return;


### PR DESCRIPTION
## Summary\n- add automatic cleanup for open production-alert issues in post-deployment monitoring\n- close stale alerts when monitoring target is not configured/reachable or API health check is success/skipped\n- keep alerts open only when API is explicitly unhealthy\n\n## Validation\n- executed monitoring workflow manually on branch\n- verified issue #149 was auto-closed with workflow comment\n