### PR TITLE
Fix Sonar remaining blockers: DI annotations and complexity hot-spots

### DIFF
--- a/apps/api/app/domains/dedup/api/routes.py
+++ b/apps/api/app/domains/dedup/api/routes.py
@@ -29,7 +29,7 @@ router = APIRouter()
 def suggest(
     entity_type: Annotated[Literal["cooperative", "roaster"], Query()],
     db: Annotated[Session, Depends(get_db)],
-    _: Annotated[object, Depends(require_role("admin", "analyst"))],
+    _: Annotated[None, Depends(require_role("admin", "analyst"))],
     threshold: Annotated[float, Query(ge=0, le=100)] = 90.0,
     limit: int = Query(50, ge=1, le=200),
 ):
@@ -49,7 +49,7 @@ def suggest(
 def merge(
     payload: MergeEntitiesIn,
     db: Annotated[Session, Depends(get_db)],
-    _: Annotated[object, Depends(require_role("admin"))],
+    _: Annotated[None, Depends(require_role("admin"))],
 ):
     """Merge two entities."""
     try:
@@ -68,7 +68,7 @@ def merge(
 def history(
     entity_type: Annotated[Literal["cooperative", "roaster"], Query()],
     db: Annotated[Session, Depends(get_db)],
-    _: Annotated[object, Depends(require_role("admin", "analyst"))],
+    _: Annotated[None, Depends(require_role("admin", "analyst"))],
     limit: int = Query(50, ge=1, le=200),
 ):
     """View merge history."""

--- a/apps/api/app/domains/features/api/routes.py
+++ b/apps/api/app/domains/features/api/routes.py
@@ -293,11 +293,82 @@ def _parse_csv_records(content: str) -> list[dict[str, str]]:
     ]
 
 
+def _build_freight_row_payload(row: dict[str, str]) -> dict[str, Any]:
+    return {
+        "route": row["route"],
+        "origin_port": row["origin_port"],
+        "destination_port": row["destination_port"],
+        "carrier": row["carrier"],
+        "container_type": row["container_type"],
+        "weight_kg": int(row["weight_kg"]),
+        "freight_cost_usd": float(row["freight_cost_usd"]),
+        "transit_days": int(row["transit_days"]),
+        "departure_date": row["departure_date"],
+        "arrival_date": row["arrival_date"],
+        "season": row["season"],
+        "fuel_price_index": float(row["fuel_price_index"]) if row.get("fuel_price_index") else None,
+        "port_congestion_score": float(row["port_congestion_score"]) if row.get("port_congestion_score") else None,
+    }
+
+
+def _build_price_row_payload(row: dict[str, str]) -> dict[str, Any]:
+    return {
+        "date": row["date"],
+        "origin_country": row["origin_country"],
+        "origin_region": row["origin_region"],
+        "variety": row["variety"],
+        "process_method": row["process_method"],
+        "quality_grade": row["quality_grade"],
+        "cupping_score": float(row["cupping_score"]) if row.get("cupping_score") else None,
+        "certifications": [part.strip() for part in row.get("certifications", "").split(",") if part.strip()],
+        "price_usd_per_kg": float(row["price_usd_per_kg"]),
+        "price_usd_per_lb": float(row["price_usd_per_lb"]),
+        "ice_c_price_usd_per_lb": float(row["ice_c_price_usd_per_lb"]),
+        "differential_usd_per_lb": float(row["differential_usd_per_lb"]),
+        "market_source": row["market_source"],
+    }
+
+
+def _validate_import(validation: dict[str, Any]) -> None:
+    if validation["valid_rows"] == 0:
+        raise HTTPException(status_code=400, detail=validation["errors"] or ["CSV validation failed"])
+
+
+async def _import_freight(
+    service: DataCollectionService, content: str, rows: list[dict[str, str]]
+) -> dict[str, Any]:
+    validation = BulkImportManager.import_data(content, "freight")
+    _validate_import(validation)
+    payload = [_build_freight_row_payload(row) for row in rows]
+    imported = await service.import_freight_data(payload)
+    return {
+        "status": "success",
+        "recordsImported": int(imported or 0),
+        "dataset": "freight",
+        "validation": _safe_validation_summary(validation),
+    }
+
+
+async def _import_price(
+    service: DataCollectionService, content: str, rows: list[dict[str, str]]
+) -> dict[str, Any]:
+    validation = BulkImportManager.import_data(content, "price")
+    _validate_import(validation)
+    payload = [_build_price_row_payload(row) for row in rows]
+    imported = await service.import_price_data(payload)
+    return {
+        "status": "success",
+        "recordsImported": int(imported or 0),
+        "dataset": "price",
+        "validation": _safe_validation_summary(validation),
+    }
+
+
 @router.post("/bulk-import")
 async def features_bulk_import(
     db: Annotated[Session, Depends(get_db)],
     _: Annotated[None, Depends(require_role("admin"))],
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File(...)],
 ):
     content = (await file.read()).decode("utf-8-sig")
     rows = _parse_csv_records(content)
@@ -308,66 +379,10 @@ async def features_bulk_import(
     headers = {header.lower() for header in rows[0].keys()}
 
     if "freight_cost_usd" in headers:
-        validation = BulkImportManager.import_data(content, "freight")
-        if validation["valid_rows"] == 0:
-            raise HTTPException(status_code=400, detail=validation["errors"] or ["CSV validation failed"])
-        payload = []
-        for row in rows:
-            payload.append(
-                {
-                    "route": row["route"],
-                    "origin_port": row["origin_port"],
-                    "destination_port": row["destination_port"],
-                    "carrier": row["carrier"],
-                    "container_type": row["container_type"],
-                    "weight_kg": int(row["weight_kg"]),
-                    "freight_cost_usd": float(row["freight_cost_usd"]),
-                    "transit_days": int(row["transit_days"]),
-                    "departure_date": row["departure_date"],
-                    "arrival_date": row["arrival_date"],
-                    "season": row["season"],
-                    "fuel_price_index": float(row["fuel_price_index"]) if row.get("fuel_price_index") else None,
-                    "port_congestion_score": float(row["port_congestion_score"]) if row.get("port_congestion_score") else None,
-                }
-            )
-        imported = await service.import_freight_data(payload)
-        return {
-            "status": "success",
-            "recordsImported": int(imported or 0),
-            "dataset": "freight",
-            "validation": _safe_validation_summary(validation),
-        }
+        return await _import_freight(service, content, rows)
 
     if "price_usd_per_kg" in headers:
-        validation = BulkImportManager.import_data(content, "price")
-        if validation["valid_rows"] == 0:
-            raise HTTPException(status_code=400, detail=validation["errors"] or ["CSV validation failed"])
-        payload = []
-        for row in rows:
-            payload.append(
-                {
-                    "date": row["date"],
-                    "origin_country": row["origin_country"],
-                    "origin_region": row["origin_region"],
-                    "variety": row["variety"],
-                    "process_method": row["process_method"],
-                    "quality_grade": row["quality_grade"],
-                    "cupping_score": float(row["cupping_score"]) if row.get("cupping_score") else None,
-                    "certifications": [part.strip() for part in row.get("certifications", "").split(",") if part.strip()],
-                    "price_usd_per_kg": float(row["price_usd_per_kg"]),
-                    "price_usd_per_lb": float(row["price_usd_per_lb"]),
-                    "ice_c_price_usd_per_lb": float(row["ice_c_price_usd_per_lb"]),
-                    "differential_usd_per_lb": float(row["differential_usd_per_lb"]),
-                    "market_source": row["market_source"],
-                }
-            )
-        imported = await service.import_price_data(payload)
-        return {
-            "status": "success",
-            "recordsImported": int(imported or 0),
-            "dataset": "price",
-            "validation": _safe_validation_summary(validation),
-        }
+        return await _import_price(service, content, rows)
 
     raise HTTPException(
         status_code=400,

--- a/apps/api/app/domains/kb/services/seed.py
+++ b/apps/api/app/domains/kb/services/seed.py
@@ -41,45 +41,60 @@ DEFAULT_DOCS: list[dict[str, Any]] = [
 ]
 
 
+def _insert_doc_postgres(db: Session, doc: dict[str, Any], language: str) -> bool:
+    if not db.bind or db.bind.dialect.name != "postgresql":
+        return False
+    insert_stmt = (
+        pg_insert(KnowledgeDoc)
+        .values(**{**doc, "language": language})
+        .on_conflict_do_nothing(constraint="uq_kb_cat_key_lang")
+        .returning(KnowledgeDoc.id)
+    )
+    inserted_id = db.execute(insert_stmt).scalar_one_or_none()
+    return inserted_id is not None
+
+
+def _load_existing_doc(db: Session, doc: dict[str, Any], language: str) -> KnowledgeDoc | None:
+    stmt = select(KnowledgeDoc).where(
+        KnowledgeDoc.category == doc["category"],
+        KnowledgeDoc.key == doc["key"],
+        KnowledgeDoc.language == language,
+    )
+    return db.execute(stmt).scalar_one_or_none()
+
+
+def _doc_has_changes(existing: KnowledgeDoc, doc: dict[str, Any]) -> bool:
+    return (
+        existing.content_md != doc["content_md"]
+        or existing.title != doc["title"]
+        or (existing.sources or {}) != (doc.get("sources") or {})
+    )
+
+
+def _apply_doc_update(existing: KnowledgeDoc, doc: dict[str, Any]) -> None:
+    existing.title = doc["title"]
+    existing.content_md = doc["content_md"]
+    existing.sources = doc.get("sources")
+
+
 def seed_default_kb(db: Session) -> dict[str, Any]:
     created = 0
     updated = 0
-    for d in DEFAULT_DOCS:
-        lang = d.get("language", "de")
-
-        # Postgres: conflict-safe insert (idempotent under concurrency)
-        if db.bind and db.bind.dialect.name == "postgresql":
-            insert_stmt = (
-                pg_insert(KnowledgeDoc)
-                .values(**{**d, "language": lang})
-                .on_conflict_do_nothing(constraint="uq_kb_cat_key_lang")
-                .returning(KnowledgeDoc.id)
-            )
-            inserted_id = db.execute(insert_stmt).scalar_one_or_none()
-            if inserted_id is not None:
-                created += 1
-                continue
-
-        # Fallback / post-insert: fetch and update if changed
-        stmt = select(KnowledgeDoc).where(
-            KnowledgeDoc.category == d["category"],
-            KnowledgeDoc.key == d["key"],
-            KnowledgeDoc.language == lang,
-        )
-        existing = db.execute(stmt).scalar_one_or_none()
-        if not existing:
-            db.add(KnowledgeDoc(**{**d, "language": lang}))
+    for doc in DEFAULT_DOCS:
+        language = doc.get("language", "de")
+        if _insert_doc_postgres(db, doc, language):
             created += 1
-        else:
-            if (
-                existing.content_md != d["content_md"]
-                or existing.title != d["title"]
-                or (existing.sources or {}) != (d.get("sources") or {})
-            ):
-                existing.title = d["title"]
-                existing.content_md = d["content_md"]
-                existing.sources = d.get("sources")
-                updated += 1
+            continue
+
+        existing = _load_existing_doc(db, doc, language)
+        if not existing:
+            db.add(KnowledgeDoc(**{**doc, "language": language}))
+            created += 1
+            continue
+
+        if _doc_has_changes(existing, doc):
+            _apply_doc_update(existing, doc)
+            updated += 1
 
     db.commit()
     return {"status": "ok", "created": created, "updated": updated}

--- a/apps/api/app/domains/knowledge_graph/api/routes.py
+++ b/apps/api/app/domains/knowledge_graph/api/routes.py
@@ -29,6 +29,7 @@ GRAPH_COMMON_RESPONSES: dict[int | str, dict[str, Any]] = {
     **NOT_FOUND_RESPONSES,
     **GRAPH_DISABLED_RESPONSES,
 }
+NOT_FOUND_DETAIL = "Not found"
 
 
 def _require_graph_enabled() -> None:
@@ -58,10 +59,12 @@ def _parse_node_id(node_id: str) -> tuple[str, int | str]:
 
 @router.get("/network", responses=GRAPH_DISABLED_RESPONSES)
 def get_network(
-    node_types: str = Query(
-        "all",
-        description="Filter by node types: cooperative, roaster, region, certification",
-    ),
+    node_types: Annotated[
+        str,
+        Query(
+            description="Filter by node types: cooperative, roaster, region, certification",
+        ),
+    ] = "all",
     *,
     db: Annotated[Session, Depends(get_db)],
     _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
@@ -89,7 +92,7 @@ def get_entity_analysis(
             parsed_id = entity_id
         return graph_service.get_entity_analysis(db, entity_type, parsed_id)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
 
 @router.get("/entity/{node_id}/connections", responses=GRAPH_COMMON_RESPONSES)
@@ -104,7 +107,7 @@ def get_entity_connections(
         entity_type, parsed_id = _parse_node_id(node_id)
         return graph_service.get_entity_analysis(db, entity_type, parsed_id)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
 
 @router.get("/communities", responses=GRAPH_DISABLED_RESPONSES)
@@ -158,7 +161,7 @@ def get_shortest_path(
             db, source_type, parsed_source_id, target_type, parsed_target_id
         )
     except ValueError:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
 
 @router.get("/path/{from_id}/{to_id}", responses=GRAPH_COMMON_RESPONSES)
@@ -177,7 +180,7 @@ def get_path_by_node_ids(
             db, source_type, parsed_source_id, target_type, parsed_target_id
         )
     except ValueError:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
 
 @router.get(
@@ -205,4 +208,4 @@ def get_hidden_connections(
             db, entity_type, parsed_id, max_hops
         )
     except ValueError:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)

--- a/apps/api/app/domains/knowledge_graph/services/graph_service.py
+++ b/apps/api/app/domains/knowledge_graph/services/graph_service.py
@@ -27,6 +27,14 @@ _graph_cache: dict[str, tuple[nx.Graph, float]] = {}
 CACHE_TTL = 300  # 5 minutes
 
 
+def _region_node_id(region_name: str) -> str:
+    return f"region_{region_name.lower().replace(' ', '_')}"
+
+
+def _cert_node_id(cert_name: str) -> str:
+    return f"certification_{cert_name.lower().replace(' ', '_')}"
+
+
 def _get_or_build_graph(db: Session) -> nx.Graph:
     """Return cached graph or build new one."""
     cache_key = "main_graph"
@@ -44,20 +52,10 @@ def _get_or_build_graph(db: Session) -> nx.Graph:
     return graph
 
 
-def build_graph(db: Session) -> nx.Graph:
-    """Build the knowledge graph from database entities."""
-    G = nx.Graph()
-
-    # Fetch all entities
-    cooperatives = db.query(Cooperative).all()
-    roasters = db.query(Roaster).all()
-    regions = db.query(Region).all()
-
-    # Add nodes for cooperatives
+def _add_cooperative_nodes(graph: nx.Graph, cooperatives: list[Cooperative]) -> None:
     for coop in cooperatives:
-        node_id = f"cooperative_{coop.id}"
-        G.add_node(
-            node_id,
+        graph.add_node(
+            f"cooperative_{coop.id}",
             label=coop.name,
             node_type="cooperative",
             properties={
@@ -70,11 +68,11 @@ def build_graph(db: Session) -> nx.Graph:
             },
         )
 
-    # Add nodes for roasters
+
+def _add_roaster_nodes(graph: nx.Graph, roasters: list[Roaster]) -> None:
     for roaster in roasters:
-        node_id = f"roaster_{roaster.id}"
-        G.add_node(
-            node_id,
+        graph.add_node(
+            f"roaster_{roaster.id}",
             label=roaster.name,
             node_type="roaster",
             properties={
@@ -87,11 +85,11 @@ def build_graph(db: Session) -> nx.Graph:
             },
         )
 
-    # Add nodes for regions
+
+def _add_region_nodes(graph: nx.Graph, regions: list[Region]) -> None:
     for region in regions:
-        node_id = f"region_{region.name.lower().replace(' ', '_')}"
-        G.add_node(
-            node_id,
+        graph.add_node(
+            _region_node_id(region.name),
             label=region.name,
             node_type="region",
             properties={
@@ -102,152 +100,169 @@ def build_graph(db: Session) -> nx.Graph:
             },
         )
 
-    # Also add region nodes from cooperative.region strings if not already present.
-    # This ensures region nodes exist even when no Region model row was created.
+
+def _ensure_region_nodes_from_coops(graph: nx.Graph, cooperatives: list[Cooperative]) -> None:
     for coop in cooperatives:
-        if coop.region:
-            region_node_id = f"region_{coop.region.lower().replace(' ', '_')}"
-            if not G.has_node(region_node_id):
-                G.add_node(
-                    region_node_id,
-                    label=coop.region,
-                    node_type="region",
-                    properties={
-                        "id": coop.region.lower(),
-                        "country": None,
-                        "production_share_pct": None,
-                        "quality_consistency_score": None,
-                    },
+        if not coop.region:
+            continue
+        region_id = _region_node_id(coop.region)
+        if graph.has_node(region_id):
+            continue
+        graph.add_node(
+            region_id,
+            label=coop.region,
+            node_type="region",
+            properties={
+                "id": coop.region.lower(),
+                "country": None,
+                "production_share_pct": None,
+                "quality_consistency_score": None,
+            },
+        )
+
+
+def _collect_certifications(cooperatives: list[Cooperative]) -> set[str]:
+    certifications: set[str] = set()
+    for coop in cooperatives:
+        if not coop.certifications:
+            continue
+        certifications.update(c.strip() for c in coop.certifications.split(",") if c.strip())
+    return certifications
+
+
+def _add_certification_nodes(graph: nx.Graph, certifications: set[str]) -> None:
+    for cert in certifications:
+        graph.add_node(
+            _cert_node_id(cert),
+            label=cert,
+            node_type="certification",
+            properties={"name": cert},
+        )
+
+
+def _add_coop_region_edges(graph: nx.Graph, cooperatives: list[Cooperative]) -> None:
+    for coop in cooperatives:
+        if not coop.region:
+            continue
+        coop_id = f"cooperative_{coop.id}"
+        region_id = _region_node_id(coop.region)
+        if graph.has_node(region_id):
+            graph.add_edge(coop_id, region_id, edge_type="LOCATED_IN", weight=1.0)
+
+
+def _add_coop_cert_edges(graph: nx.Graph, cooperatives: list[Cooperative]) -> None:
+    for coop in cooperatives:
+        if not coop.certifications:
+            continue
+        coop_id = f"cooperative_{coop.id}"
+        for cert in (c.strip() for c in coop.certifications.split(",")):
+            if not cert:
+                continue
+            cert_id = _cert_node_id(cert)
+            if graph.has_node(cert_id):
+                graph.add_edge(coop_id, cert_id, edge_type="HAS_CERTIFICATION", weight=1.0)
+
+
+def _add_roaster_region_edges(graph: nx.Graph, roasters: list[Roaster], cooperatives: list[Cooperative]) -> None:
+    unique_region_ids = {_region_node_id(coop.region) for coop in cooperatives if coop.region}
+    for roaster in roasters:
+        if not roaster.peru_focus:
+            continue
+        roaster_id = f"roaster_{roaster.id}"
+        for region_id in unique_region_ids:
+            if graph.has_node(region_id):
+                graph.add_edge(roaster_id, region_id, edge_type="SOURCES_FROM", weight=1.0)
+
+
+def _add_similar_coop_edges(graph: nx.Graph, cooperatives: list[Cooperative]) -> None:
+    for i, coop1 in enumerate(cooperatives):
+        for coop2 in cooperatives[i + 1 :]:
+            if not coop1.region or coop1.region != coop2.region:
+                continue
+            if not coop1.certifications or not coop2.certifications:
+                continue
+            certs1 = set(c.strip() for c in coop1.certifications.split(","))
+            certs2 = set(c.strip() for c in coop2.certifications.split(","))
+            if certs1 & certs2:
+                graph.add_edge(
+                    f"cooperative_{coop1.id}",
+                    f"cooperative_{coop2.id}",
+                    edge_type="SIMILAR_PROFILE",
+                    weight=0.7,
                 )
 
-    # Collect unique certifications
-    certifications_set: set[str] = set()
-    for coop in cooperatives:
-        if coop.certifications:
-            certs = [c.strip() for c in coop.certifications.split(",")]
-            certifications_set.update(certs)
 
-    # Add nodes for certifications
-    for cert in certifications_set:
-        if cert:
-            node_id = f"certification_{cert.lower().replace(' ', '_')}"
-            G.add_node(
-                node_id,
-                label=cert,
-                node_type="certification",
-                properties={"name": cert},
+def _add_similar_roaster_edges(graph: nx.Graph, roasters: list[Roaster]) -> None:
+    for i, roaster1 in enumerate(roasters):
+        for roaster2 in roasters[i + 1 :]:
+            if not roaster1.city or roaster1.city != roaster2.city:
+                continue
+            if not roaster1.price_position or roaster1.price_position != roaster2.price_position:
+                continue
+            graph.add_edge(
+                f"roaster_{roaster1.id}",
+                f"roaster_{roaster2.id}",
+                edge_type="SIMILAR_PROFILE",
+                weight=0.7,
             )
 
-    # Add edges: cooperative -> region (LOCATED_IN)
-    for coop in cooperatives:
-        if coop.region:
-            coop_id = f"cooperative_{coop.id}"
-            region_id = f"region_{coop.region.lower().replace(' ', '_')}"
-            if G.has_node(region_id):
-                G.add_edge(coop_id, region_id, edge_type="LOCATED_IN", weight=1.0)
 
-    # Add edges: cooperative -> certification (HAS_CERTIFICATION)
-    for coop in cooperatives:
-        if coop.certifications:
-            coop_id = f"cooperative_{coop.id}"
-            certs = [c.strip() for c in coop.certifications.split(",")]
-            for cert in certs:
-                if cert:
-                    cert_id = f"certification_{cert.lower().replace(' ', '_')}"
-                    if G.has_node(cert_id):
-                        G.add_edge(
-                            coop_id, cert_id, edge_type="HAS_CERTIFICATION", weight=1.0
-                        )
-
-    # Add edges: roaster -> region (SOURCES_FROM)
-    # NOTE: This creates a SOURCES_FROM edge from every Peru-focused roaster to every region
-    # that has cooperatives. This is an ASSUMPTION that roasters with Peru focus might source
-    # from any Peru region. In a production system, this should be based on actual sourcing
-    # relationships tracked in the database.
-    # Optimization: Collect unique regions first to avoid redundant iteration
-    unique_region_ids = {
-        f"region_{coop.region.lower().replace(' ', '_')}"
-        for coop in cooperatives
-        if coop.region
-    }
-    for roaster in roasters:
-        if roaster.peru_focus:
-            roaster_id = f"roaster_{roaster.id}"
-            for region_id in unique_region_ids:
-                if G.has_node(region_id):
-                    G.add_edge(
-                        roaster_id, region_id, edge_type="SOURCES_FROM", weight=1.0
-                    )
-
-    # Add edges: cooperative -> cooperative (SIMILAR_PROFILE)
-    # Similar if they share region and at least one certification
-    coop_list = list(cooperatives)
-    for i, coop1 in enumerate(coop_list):
-        for coop2 in coop_list[i + 1 :]:
-            if coop1.region and coop2.region and coop1.region == coop2.region:
-                # Check if they share certifications
-                if coop1.certifications and coop2.certifications:
-                    certs1 = set(c.strip() for c in coop1.certifications.split(","))
-                    certs2 = set(c.strip() for c in coop2.certifications.split(","))
-                    if certs1 & certs2:  # Intersection
-                        coop1_id = f"cooperative_{coop1.id}"
-                        coop2_id = f"cooperative_{coop2.id}"
-                        G.add_edge(
-                            coop1_id,
-                            coop2_id,
-                            edge_type="SIMILAR_PROFILE",
-                            weight=0.7,
-                        )
-
-    # Add edges: roaster -> roaster (SIMILAR_PROFILE)
-    # Similar if they have same city and price position
-    roaster_list = list(roasters)
-    for i, r1 in enumerate(roaster_list):
-        for r2 in roaster_list[i + 1 :]:
-            if (
-                r1.city
-                and r2.city
-                and r1.city == r2.city
-                and r1.price_position
-                and r2.price_position
-                and r1.price_position == r2.price_position
-            ):
-                r1_id = f"roaster_{r1.id}"
-                r2_id = f"roaster_{r2.id}"
-                G.add_edge(r1_id, r2_id, edge_type="SIMILAR_PROFILE", weight=0.7)
-
-    # Add edges: roaster -> cooperative (TRADES_WITH)
-    # A roaster trades with cooperatives located in regions it sources from.
-    # Build a lookup: region_node_id -> list of cooperative node IDs
+def _build_region_to_coops(cooperatives: list[Cooperative]) -> dict[str, list[str]]:
     region_to_coops: dict[str, list[str]] = {}
     for coop in cooperatives:
-        if coop.region:
-            region_node_id = f"region_{coop.region.lower().replace(' ', '_')}"
-            region_to_coops.setdefault(region_node_id, []).append(
-                f"cooperative_{coop.id}"
-            )
+        if not coop.region:
+            continue
+        region_to_coops.setdefault(_region_node_id(coop.region), []).append(f"cooperative_{coop.id}")
+    return region_to_coops
 
+
+def _add_roaster_coop_trade_edges(graph: nx.Graph, roasters: list[Roaster], cooperatives: list[Cooperative]) -> None:
+    region_to_coops = _build_region_to_coops(cooperatives)
     for roaster in roasters:
-        if roaster.peru_focus:
-            roaster_id = f"roaster_{roaster.id}"
-            for region_id, coop_ids in region_to_coops.items():
-                if G.has_node(region_id) and G.has_edge(roaster_id, region_id):
-                    for coop_id in coop_ids:
-                        if G.has_node(coop_id):
-                            G.add_edge(
-                                roaster_id,
-                                coop_id,
-                                edge_type="TRADES_WITH",
-                                weight=0.8,
-                            )
+        if not roaster.peru_focus:
+            continue
+        roaster_id = f"roaster_{roaster.id}"
+        for region_id, coop_ids in region_to_coops.items():
+            if not graph.has_node(region_id) or not graph.has_edge(roaster_id, region_id):
+                continue
+            for coop_id in coop_ids:
+                if graph.has_node(coop_id):
+                    graph.add_edge(
+                        roaster_id,
+                        coop_id,
+                        edge_type="TRADES_WITH",
+                        weight=0.8,
+                    )
+
+
+def build_graph(db: Session) -> nx.Graph:
+    """Build the knowledge graph from database entities."""
+    graph = nx.Graph()
+
+    # Fetch all entities
+    cooperatives = db.query(Cooperative).all()
+    roasters = db.query(Roaster).all()
+    regions = db.query(Region).all()
+
+    _add_cooperative_nodes(graph, cooperatives)
+    _add_roaster_nodes(graph, roasters)
+    _add_region_nodes(graph, regions)
+    _ensure_region_nodes_from_coops(graph, cooperatives)
+    _add_certification_nodes(graph, _collect_certifications(cooperatives))
+    _add_coop_region_edges(graph, cooperatives)
+    _add_coop_cert_edges(graph, cooperatives)
+    _add_roaster_region_edges(graph, roasters, cooperatives)
+    _add_similar_coop_edges(graph, cooperatives)
+    _add_similar_roaster_edges(graph, roasters)
+    _add_roaster_coop_trade_edges(graph, roasters, cooperatives)
 
     logger.info(
         "knowledge_graph.graph_built",
-        nodes=G.number_of_nodes(),
-        edges=G.number_of_edges(),
+        nodes=graph.number_of_nodes(),
+        edges=graph.number_of_edges(),
     )
 
-    return G
+    return graph
 
 
 def get_network_data(db: Session, node_types: str = "all") -> NetworkData:

--- a/apps/api/app/domains/margins/api/routes.py
+++ b/apps/api/app/domains/margins/api/routes.py
@@ -17,9 +17,9 @@ from app.domains.margins.services.calculator import calc_margin
 
 router = APIRouter()
 DbSessionDep = Annotated[Session, Depends(get_db)]
-AnalystPermissionDep = Annotated[object, Depends(require_role("admin", "analyst"))]
+AnalystPermissionDep = Annotated[None, Depends(require_role("admin", "analyst"))]
 ViewerPermissionDep = Annotated[
-    object, Depends(require_role("admin", "analyst", "viewer"))
+    None, Depends(require_role("admin", "analyst", "viewer"))
 ]
 
 

--- a/apps/api/app/domains/market/api/routes.py
+++ b/apps/api/app/domains/market/api/routes.py
@@ -33,9 +33,9 @@ router = APIRouter()
 
 DbSessionDep = Annotated[Session, Depends(get_db)]
 ViewerPermissionDep = Annotated[
-    object, Depends(require_role("admin", "analyst", "viewer"))
+    None, Depends(require_role("admin", "analyst", "viewer"))
 ]
-AnalystPermissionDep = Annotated[object, Depends(require_role("admin", "analyst"))]
+AnalystPermissionDep = Annotated[None, Depends(require_role("admin", "analyst"))]
 AnalystUserDep = Annotated[User, Depends(require_role("admin", "analyst"))]
 
 WS_POLICY_VIOLATION_CODE = 1008


### PR DESCRIPTION
## Summary\n- replace remaining FastAPI DI object aliases with None-typed Annotated dependencies\n- refactor eatures_bulk_import into small helpers and annotate file upload dependency\n- refactor KB seed service into helper-based upsert flow\n- reduce complexity in knowledge-graph build path by splitting uild_graph into focused helper functions\n- deduplicate knowledge-graph API not-found literal\n\n## Validation\n- ruff check on touched modules\n- mypy on touched modules\n- pytest: dedup/kb/knowledge-graph/market/margins suites (99 passed, 2 skipped)\n