### PR TITLE
fix: resolve remaining Sonar blockers (deps + complexity)

### DIFF
--- a/apps/api/app/domains/knowledge_graph/services/graph_service.py
+++ b/apps/api/app/domains/knowledge_graph/services/graph_service.py
@@ -216,23 +216,39 @@ def _build_region_to_coops(cooperatives: list[Cooperative]) -> dict[str, list[st
     return region_to_coops
 
 
+def _roaster_trade_targets(
+    graph: nx.Graph, roaster_id: str, region_to_coops: dict[str, list[str]]
+) -> list[str]:
+    targets: list[str] = []
+    for region_id, coop_ids in region_to_coops.items():
+        if not graph.has_node(region_id):
+            continue
+        if not graph.has_edge(roaster_id, region_id):
+            continue
+        targets.extend(coop_id for coop_id in coop_ids if graph.has_node(coop_id))
+    return targets
+
+
+def _add_roaster_trade_edges_for_targets(
+    graph: nx.Graph, roaster_id: str, coop_ids: list[str]
+) -> None:
+    for coop_id in coop_ids:
+        graph.add_edge(
+            roaster_id,
+            coop_id,
+            edge_type="TRADES_WITH",
+            weight=0.8,
+        )
+
+
 def _add_roaster_coop_trade_edges(graph: nx.Graph, roasters: list[Roaster], cooperatives: list[Cooperative]) -> None:
     region_to_coops = _build_region_to_coops(cooperatives)
     for roaster in roasters:
         if not roaster.peru_focus:
             continue
         roaster_id = f"roaster_{roaster.id}"
-        for region_id, coop_ids in region_to_coops.items():
-            if not graph.has_node(region_id) or not graph.has_edge(roaster_id, region_id):
-                continue
-            for coop_id in coop_ids:
-                if graph.has_node(coop_id):
-                    graph.add_edge(
-                        roaster_id,
-                        coop_id,
-                        edge_type="TRADES_WITH",
-                        weight=0.8,
-                    )
+        targets = _roaster_trade_targets(graph, roaster_id, region_to_coops)
+        _add_roaster_trade_edges_for_targets(graph, roaster_id, targets)
 
 
 def build_graph(db: Session) -> nx.Graph:

--- a/apps/api/app/domains/ml_training/api/routes.py
+++ b/apps/api/app/domains/ml_training/api/routes.py
@@ -35,7 +35,7 @@ MLTrainingModelType = Literal["freight_cost", "coffee_price"]
 def train_model(
     model_type: MLTrainingModelType,
     db: Annotated[Session, Depends(get_db)],
-    _: Annotated[object, Depends(require_role("admin"))],
+    _: Annotated[None, Depends(require_role("admin"))],
 ):
     """Trigger model training.
 
@@ -56,7 +56,7 @@ def train_model(
 @router.get("/training-status", response_model=list[TrainingStatusOut])
 async def get_training_status(
     db: Annotated[Session, Depends(get_db)],
-    _: Annotated[object, Depends(require_role("admin", "analyst"))],
+    _: Annotated[None, Depends(require_role("admin", "analyst"))],
     model_type: Annotated[MLTrainingModelType | None, Query()] = None,
 ):
     """Get training pipeline status."""
@@ -68,7 +68,7 @@ async def get_training_status(
 @router.get("/optimal-purchase-timing", response_model=PurchaseTimingOut)
 def optimal_purchase_timing(
     db: Annotated[Session, Depends(get_db)],
-    _: Annotated[object, Depends(require_role("admin", "analyst"))],
+    _: Annotated[None, Depends(require_role("admin", "analyst"))],
     origin_region: str | None = None,
     target_quantity_kg: float | None = None,
 ):
@@ -82,7 +82,7 @@ def optimal_purchase_timing(
 @router.get("/price-forecast", response_model=PriceForecastOut)
 def price_forecast(
     db: Annotated[Session, Depends(get_db)],
-    _: Annotated[object, Depends(require_role("admin", "analyst"))],
+    _: Annotated[None, Depends(require_role("admin", "analyst"))],
     origin_region: str | None = None,
     days: int = Query(30, ge=1, le=90),
 ):

--- a/apps/api/app/domains/news/api/routes.py
+++ b/apps/api/app/domains/news/api/routes.py
@@ -21,7 +21,7 @@ def _normalize_country_code(country: str) -> str:
 @router.get("/", response_model=list[NewsItemOut])
 def list_news(
     db: Annotated[Session, Depends(get_db)],
-    _: Annotated[object, Depends(require_role("admin", "analyst", "viewer"))],
+    _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
     topic: str = Query("peru coffee", min_length=1, max_length=100),
     limit: int = Query(100, ge=1, le=500),
     days: int = Query(7, ge=1, le=365),
@@ -35,7 +35,7 @@ def list_news(
 @router.post("/refresh", response_model=NewsRefreshResponse)
 def refresh(
     db: Annotated[Session, Depends(get_db)],
-    _: Annotated[object, Depends(require_role("admin", "analyst"))],
+    _: Annotated[None, Depends(require_role("admin", "analyst"))],
     topic: str = Query("peru coffee", min_length=1, max_length=100),
     country: str = Query("PE", pattern=ISO2_COUNTRY_PATTERN),
     max_items: int = Query(25, ge=1, le=200),

--- a/apps/api/app/domains/news/services/refresh.py
+++ b/apps/api/app/domains/news/services/refresh.py
@@ -98,6 +98,114 @@ def _upsert_news_items(
     return created, updated
 
 
+def _already_seen(url: str | None, stored_urls: set[str]) -> bool:
+    if not url or url in stored_urls:
+        return True
+    stored_urls.add(url)
+    return False
+
+
+def _refresh_from_perplexity(
+    db: Session,
+    *,
+    topic: str,
+    country: str | None,
+    max_items: int,
+    now: datetime,
+    stored_urls: set[str],
+) -> tuple[int, int, list[str], bool]:
+    created = 0
+    updated = 0
+    errors: list[str] = []
+    provider_used = False
+    client = PerplexityClient()
+
+    try:
+        queries = [f"{topic} {query_suffix}" for query_suffix in DEFAULT_NEWS_QUERIES]
+        for query_text in queries:
+            if created + updated >= max_items:
+                break
+            try:
+                raw_results = client.search(
+                    query_text,
+                    max_results=min(10, max_items),
+                    country=country or "DE",
+                    max_tokens_per_page=384,
+                )
+                results = [
+                    {
+                        "title": _coerce_result_field(item, "title"),
+                        "url": _coerce_result_field(item, "url"),
+                        "snippet": _coerce_result_field(item, "snippet"),
+                        "published_at": _coerce_result_field(item, "published_date"),
+                    }
+                    for item in raw_results
+                    if not _already_seen(_coerce_result_field(item, "url"), stored_urls)
+                ]
+                c, u = _upsert_news_items(
+                    db,
+                    topic=topic,
+                    country=country,
+                    provider="perplexity",
+                    query=query_text,
+                    results=results,
+                    max_items=max_items - (created + updated),
+                    now=now,
+                )
+                created += c
+                updated += u
+            except Exception:
+                db.rollback()
+                errors.append(f"perplexity query failed: {query_text}")
+
+        provider_used = bool(created or updated)
+        return created, updated, errors, provider_used
+    finally:
+        client.close()
+
+
+def _refresh_from_google_rss(
+    db: Session,
+    *,
+    topic: str,
+    country: str | None,
+    max_items: int,
+    now: datetime,
+    already_created: int,
+    already_updated: int,
+    stored_urls: set[str],
+) -> tuple[int, int, list[str], bool]:
+    remaining = max_items - (already_created + already_updated)
+    if remaining <= 0:
+        return 0, 0, [], False
+
+    try:
+        query = quote_plus(topic)
+        rss_results = [
+            item
+            for item in _fetch_google_news_rss(
+                topic,
+                country=country,
+                max_items=max_items,
+            )
+            if not _already_seen(item.get("url"), stored_urls)
+        ]
+        created, updated = _upsert_news_items(
+            db,
+            topic=topic,
+            country=country,
+            provider="google_news_rss",
+            query=query,
+            results=rss_results,
+            max_items=remaining,
+            now=now,
+        )
+        return created, updated, [], bool(created or updated)
+    except Exception:
+        db.rollback()
+        return 0, 0, ["google_news_rss failed"], False
+
+
 def _fetch_google_news_rss(
     topic: str,
     *,
@@ -161,95 +269,41 @@ def refresh_news(
     provider_used: str | None = None
     stored_urls: set[str] = set()
 
-    def _sanitize_error(message: str) -> str:
-        # Keep client-facing errors generic; full exception details stay in server logs.
-        return message
-
-    def _already_seen(url: str | None) -> bool:
-        if not url or url in stored_urls:
-            return True
-        stored_urls.add(url)
-        return False
-
     if settings.PERPLEXITY_API_KEY:
-        client = PerplexityClient()
-        try:
-            queries = [f"{topic} {q}" for q in DEFAULT_NEWS_QUERIES]
-            providers_attempted.append("perplexity")
-
-            for q in queries:
-                if created + updated >= max_items:
-                    break
-                try:
-                    raw_results = client.search(
-                        q,
-                        max_results=min(10, max_items),
-                        country=country or "DE",
-                        max_tokens_per_page=384,
-                    )
-                    results = [
-                        {
-                            "title": _coerce_result_field(item, "title"),
-                            "url": _coerce_result_field(item, "url"),
-                            "snippet": _coerce_result_field(item, "snippet"),
-                            "published_at": _coerce_result_field(item, "published_date"),
-                        }
-                        for item in raw_results
-                        if not _already_seen(_coerce_result_field(item, "url"))
-                    ]
-                    c, u = _upsert_news_items(
-                        db,
-                        topic=topic,
-                        country=country,
-                        provider="perplexity",
-                        query=q,
-                        results=results,
-                        max_items=max_items - (created + updated),
-                        now=now,
-                    )
-                    created += c
-                    updated += u
-                except Exception:
-                    db.rollback()
-                    errors.append(_sanitize_error(f"perplexity query failed: {q}"))
-
-            if created or updated:
-                provider_used = "perplexity"
-        finally:
-            client.close()
+        providers_attempted.append("perplexity")
+        p_created, p_updated, p_errors, p_used = _refresh_from_perplexity(
+            db,
+            topic=topic,
+            country=country,
+            max_items=max_items,
+            now=now,
+            stored_urls=stored_urls,
+        )
+        created += p_created
+        updated += p_updated
+        errors.extend(p_errors)
+        if p_used:
+            provider_used = "perplexity"
     else:
         errors.append("perplexity unavailable: PERPLEXITY_API_KEY not set")
 
     if created + updated < max_items:
-        try:
-            providers_attempted.append("google_news_rss")
-            query = quote_plus(topic)
-            rss_results = [
-                item
-                for item in _fetch_google_news_rss(
-                    topic,
-                    country=country,
-                    max_items=max_items,
-                )
-                if not _already_seen(item.get("url"))
-            ]
-            c, u = _upsert_news_items(
-                db,
-                topic=topic,
-                country=country,
-                provider="google_news_rss",
-                query=query,
-                results=rss_results,
-                max_items=max_items - (created + updated),
-                now=now,
-            )
-            created += c
-            updated += u
-            if (c or u) and provider_used is None:
-                provider_used = "google_news_rss"
-        except Exception:
-            db.rollback()
-            errors.append(_sanitize_error("google_news_rss failed"))
+        providers_attempted.append("google_news_rss")
+        r_created, r_updated, r_errors, r_used = _refresh_from_google_rss(
+            db,
+            topic=topic,
+            country=country,
+            max_items=max_items,
+            now=now,
+            already_created=created,
+            already_updated=updated,
+            stored_urls=stored_urls,
+        )
+        created += r_created
+        updated += r_updated
+        errors.extend(r_errors)
+        if r_used and provider_used is None:
+            provider_used = "google_news_rss"
 
     status = "ok" if (created or updated) else "failed"
     return {

--- a/apps/api/app/domains/outreach/services/generator.py
+++ b/apps/api/app/domains/outreach/services/generator.py
@@ -15,46 +15,47 @@ Language = Literal["de", "en", "es"]
 Purpose = Literal["sourcing_pitch", "sample_request"]
 
 
-def _template(
-    language: Language, *, purpose: Purpose, entity: Any, counterpart: str | None
+def _sourcing_pitch_template(
+    language: Language, *, name: str, website: str | None, counterpart: str | None
 ) -> str:
-    name = getattr(entity, "name", "")
-    website = getattr(entity, "website", None)
-    region = getattr(entity, "region", None)
-    contact_hint = getattr(entity, "contact_email", None)
-
-    if purpose == "sourcing_pitch":
-        if language == "de":
-            return (
-                f"Hallo {counterpart or 'Team'},\n\n"
-                "ich baue gerade ein Direct-Trade-Sourcing fuer Spezialitaetenkaffee aus Peru auf. "
-                f"Ich bin auf {name} gestossen{f' ({website})' if website else ''}. "
-                "Ich wuerde gerne kurz verstehen, ob ihr grundsaetzlich offen fuer gruene Rohkaffee-Angebote aus Peru seid "
-                "(Microlots/Koop-Lots) und wie euer Prozess fuer Samples/Preise aussieht.\n\n"
-                "Wenn das passt, schicke ich gerne ein kurzes Profil + erste Lot-Optionen (Region/Varietaet/Processing) "
-                "und wir stimmen MOQ/Incoterms ab.\n\n"
-                "Viele Gruesse\nCoffeeStudio"
-            )
-        if language == "en":
-            return (
-                f"Hi {counterpart or 'team'},\n\n"
-                "I'm building a direct-trade sourcing pipeline for specialty coffee from Peru. "
-                f"I came across {name}{f' ({website})' if website else ''}. "
-                "Are you open to green coffee offers from Peru, and what is your process for samples and pricing?\n\n"
-                "If relevant, I can share a short profile and a few lot options (region/variety/processing) and align MOQ/Incoterms.\n\n"
-                "Best regards\nCoffeeStudio"
-            )
-        # es
+    if language == "de":
         return (
-            f"Hola {counterpart or 'equipo'},\n\n"
-            "Estoy construyendo un flujo de abastecimiento direct-trade de cafe de especialidad desde Peru. "
-            f"He encontrado {name}{f' ({website})' if website else ''}. "
-            "?Estan abiertos a ofertas de cafe verde de Peru y cual es su proceso para muestras y precios?\n\n"
-            "Si encaja, puedo enviar un perfil breve y algunas opciones de lotes (region/variedad/proceso) y acordar MOQ/Incoterms.\n\n"
-            "Saludos\nCoffeeStudio"
+            f"Hallo {counterpart or 'Team'},\n\n"
+            "ich baue gerade ein Direct-Trade-Sourcing fuer Spezialitaetenkaffee aus Peru auf. "
+            f"Ich bin auf {name} gestossen{f' ({website})' if website else ''}. "
+            "Ich wuerde gerne kurz verstehen, ob ihr grundsaetzlich offen fuer gruene Rohkaffee-Angebote aus Peru seid "
+            "(Microlots/Koop-Lots) und wie euer Prozess fuer Samples/Preise aussieht.\n\n"
+            "Wenn das passt, schicke ich gerne ein kurzes Profil + erste Lot-Optionen (Region/Varietaet/Processing) "
+            "und wir stimmen MOQ/Incoterms ab.\n\n"
+            "Viele Gruesse\nCoffeeStudio"
         )
+    if language == "en":
+        return (
+            f"Hi {counterpart or 'team'},\n\n"
+            "I'm building a direct-trade sourcing pipeline for specialty coffee from Peru. "
+            f"I came across {name}{f' ({website})' if website else ''}. "
+            "Are you open to green coffee offers from Peru, and what is your process for samples and pricing?\n\n"
+            "If relevant, I can share a short profile and a few lot options (region/variety/processing) and align MOQ/Incoterms.\n\n"
+            "Best regards\nCoffeeStudio"
+        )
+    return (
+        f"Hola {counterpart or 'equipo'},\n\n"
+        "Estoy construyendo un flujo de abastecimiento direct-trade de cafe de especialidad desde Peru. "
+        f"He encontrado {name}{f' ({website})' if website else ''}. "
+        "?Estan abiertos a ofertas de cafe verde de Peru y cual es su proceso para muestras y precios?\n\n"
+        "Si encaja, puedo enviar un perfil breve y algunas opciones de lotes (region/variedad/proceso) y acordar MOQ/Incoterms.\n\n"
+        "Saludos\nCoffeeStudio"
+    )
 
-    # sample_request
+
+def _sample_request_template(
+    language: Language,
+    *,
+    region: str | None,
+    website: str | None,
+    contact_hint: str | None,
+    counterpart: str | None,
+) -> str:
     if language == "de":
         return (
             f"Hallo {counterpart or 'Team'},\n\n"
@@ -79,6 +80,28 @@ def _template(
         "(MOQ, Incoterms, ventana de cosecha, precios indicativos)?\n\n"
         f"Contexto: CoffeeStudio. Fuente: {website or '-'}\n\n"
         "Gracias y saludos\nCoffeeStudio"
+    )
+
+
+def _template(
+    language: Language, *, purpose: Purpose, entity: Any, counterpart: str | None
+) -> str:
+    name = getattr(entity, "name", "")
+    website = getattr(entity, "website", None)
+    region = getattr(entity, "region", None)
+    contact_hint = getattr(entity, "contact_email", None)
+
+    if purpose == "sourcing_pitch":
+        return _sourcing_pitch_template(
+            language, name=name, website=website, counterpart=counterpart
+        )
+
+    return _sample_request_template(
+        language,
+        region=region,
+        website=website,
+        contact_hint=contact_hint,
+        counterpart=counterpart,
     )
 
 

--- a/apps/api/app/domains/peru_sourcing/api/routes.py
+++ b/apps/api/app/domains/peru_sourcing/api/routes.py
@@ -29,10 +29,11 @@ from app.services.seed_peru_regions import seed_peru_regions
 router = APIRouter()
 DbSessionDep = Annotated[Session, Depends(get_db)]
 ViewerPermissionDep = Annotated[
-    object, Depends(require_role("admin", "analyst", "viewer"))
+    None, Depends(require_role("admin", "analyst", "viewer"))
 ]
-AnalystPermissionDep = Annotated[object, Depends(require_role("admin", "analyst"))]
-AdminPermissionDep = Annotated[object, Depends(require_role("admin"))]
+AnalystPermissionDep = Annotated[None, Depends(require_role("admin", "analyst"))]
+AdminPermissionDep = Annotated[None, Depends(require_role("admin"))]
+NOT_FOUND_DETAIL = "Not found"
 
 
 @router.get("/regions", response_model=list[RegionBasicResponse])
@@ -85,7 +86,7 @@ def get_region_intelligence(
     if not intelligence:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Not found",
+            detail=NOT_FOUND_DETAIL,
         )
 
     return intelligence
@@ -118,7 +119,7 @@ def get_cooperative_sourcing_analysis(
         analysis = analyzer.analyze_for_sourcing(coop_id, force_refresh=False)
         return analysis
     except ValueError:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=NOT_FOUND_DETAIL)
 
 
 @router.post("/cooperatives/{coop_id}/analyze", response_model=SourcingAnalysisResponse)
@@ -152,7 +153,7 @@ def analyze_cooperative_for_sourcing(
         analysis = analyzer.analyze_for_sourcing(coop_id, force_refresh=force_refresh)
         return analysis
     except ValueError:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=NOT_FOUND_DETAIL)
 
 
 @router.post("/regions/refresh")

--- a/apps/api/app/domains/quality_alerts/api/routes.py
+++ b/apps/api/app/domains/quality_alerts/api/routes.py
@@ -22,8 +22,8 @@ anomalies_router = APIRouter()
 ENTITY_TYPE_PATTERN = r"^[a-z][a-z0-9_]{1,31}$"
 AlertSeverity = Literal["info", "warning", "critical"]
 DbSessionDep = Annotated[Session, Depends(get_db)]
-AnalystPermissionDep = Annotated[object, Depends(require_role("admin", "analyst"))]
-AdminPermissionDep = Annotated[object, Depends(require_role("admin"))]
+AnalystPermissionDep = Annotated[None, Depends(require_role("admin", "analyst"))]
+AdminPermissionDep = Annotated[None, Depends(require_role("admin"))]
 
 
 def _require_anomaly_detection_enabled() -> None:


### PR DESCRIPTION
## Summary
- replace remaining dependency placeholders typed as object with None in API routes
- remove repeated "Not found" literal in peru sourcing routes
- refactor news refresh flow into provider-specific helpers to reduce cognitive complexity
- split outreach template generation by purpose/language helper to reduce complexity
- split roaster->coop trade-edge building into focused helpers in knowledge graph service

## Validation
- ruff check on touched files
- mypy on touched files
- pytest subset:
  - test_news_service.py
  - test_news_api.py
  - test_peru_sourcing_api.py
  - test_quality_alerts_api.py
  - test_outreach_service.py
  - test_knowledge_graph.py
  - test_ml_routes_api.py
  - test_ml_predictions_batch.py
