### PR TITLE
fix: clear next Sonar batch (Annotated params + duplicate literal)

### DIFF
--- a/apps/api/app/domains/ml_predictions/api/routes.py
+++ b/apps/api/app/domains/ml_predictions/api/routes.py
@@ -122,7 +122,7 @@ async def get_freight_cost_trend(
     route: str,
     db: Annotated[Session, Depends(get_db)],
     _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
-    months_back: int = Query(12, ge=1, le=120),
+    months_back: Annotated[int, Query(ge=1, le=120)] = 12,
 ):
     """Get historical freight cost trend for a route."""
     service = FreightPredictionService(db)
@@ -229,7 +229,9 @@ async def calculate_optimal_purchase_timing(
 @router.get("/tasks/{task_id}", response_model=AsyncTaskStatus)
 async def ml_task_status(
     _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
-    task_id: str = Path(min_length=8, max_length=100, pattern=r"^[A-Za-z0-9._:-]+$"),
+    task_id: Annotated[
+        str, Path(min_length=8, max_length=100, pattern=r"^[A-Za-z0-9._:-]+$")
+    ],
 ):
     """Check async ML task status."""
     res = AsyncResult(task_id, app=celery)

--- a/apps/api/app/domains/ml_training/api/routes.py
+++ b/apps/api/app/domains/ml_training/api/routes.py
@@ -84,7 +84,7 @@ def price_forecast(
     db: Annotated[Session, Depends(get_db)],
     _: Annotated[None, Depends(require_role("admin", "analyst"))],
     origin_region: str | None = None,
-    days: int = Query(30, ge=1, le=90),
+    days: Annotated[int, Query(ge=1, le=90)] = 30,
 ):
     """Get price forecast for next N days."""
     result = get_price_forecast(db, origin_region=origin_region, days_ahead=days)

--- a/apps/api/app/domains/news/api/routes.py
+++ b/apps/api/app/domains/news/api/routes.py
@@ -22,9 +22,9 @@ def _normalize_country_code(country: str) -> str:
 def list_news(
     db: Annotated[Session, Depends(get_db)],
     _: Annotated[None, Depends(require_role("admin", "analyst", "viewer"))],
-    topic: str = Query("peru coffee", min_length=1, max_length=100),
-    limit: int = Query(100, ge=1, le=500),
-    days: int = Query(7, ge=1, le=365),
+    topic: Annotated[str, Query(min_length=1, max_length=100)] = "peru coffee",
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    days: Annotated[int, Query(ge=1, le=365)] = 7,
 ):
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     q = db.query(NewsItem).filter(NewsItem.topic == topic)
@@ -36,9 +36,9 @@ def list_news(
 def refresh(
     db: Annotated[Session, Depends(get_db)],
     _: Annotated[None, Depends(require_role("admin", "analyst"))],
-    topic: str = Query("peru coffee", min_length=1, max_length=100),
-    country: str = Query("PE", pattern=ISO2_COUNTRY_PATTERN),
-    max_items: int = Query(25, ge=1, le=200),
+    topic: Annotated[str, Query(min_length=1, max_length=100)] = "peru coffee",
+    country: Annotated[str, Query(pattern=ISO2_COUNTRY_PATTERN)] = "PE",
+    max_items: Annotated[int, Query(ge=1, le=200)] = 25,
 ):
     return refresh_news(
         db,

--- a/apps/api/app/domains/quality_alerts/api/routes.py
+++ b/apps/api/app/domains/quality_alerts/api/routes.py
@@ -42,8 +42,8 @@ def list_alerts(
     entity_type: Annotated[str | None, Query(pattern=ENTITY_TYPE_PATTERN)] = None,
     severity: AlertSeverity | None = None,
     acknowledged: bool | None = None,
-    limit: int = Query(100, ge=1, le=500),
-    offset: int = Query(0, ge=0),
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    offset: Annotated[int, Query(ge=0)] = 0,
 ):
     """List quality alerts with optional filters."""
     alerts = quality_alerts.get_alerts(
@@ -86,7 +86,7 @@ def acknowledge_alert(
 def check_now(
     db: DbSessionDep,
     _: AdminPermissionDep,
-    threshold: float = Query(5.0, ge=0.0, le=100.0),
+    threshold: Annotated[float, Query(ge=0.0, le=100.0)] = 5.0,
 ):
     """Manually trigger alert check."""
     result = quality_alerts.check_all_entities(db, threshold=threshold)
@@ -105,8 +105,8 @@ def list_anomalies(
     entity_type: Annotated[str | None, Query(pattern=ENTITY_TYPE_PATTERN)] = None,
     severity: AlertSeverity | None = None,
     acknowledged: bool | None = None,
-    limit: int = Query(100, ge=1, le=500),
-    offset: int = Query(0, ge=0),
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    offset: Annotated[int, Query(ge=0)] = 0,
 ):
     """List anomaly alerts (Isolation Forest score anomalies and Z-Score price anomalies)."""
     _require_anomaly_detection_enabled()

--- a/apps/api/app/domains/quality_alerts/services/alerts.py
+++ b/apps/api/app/domains/quality_alerts/services/alerts.py
@@ -11,6 +11,8 @@ from app.models.quality_alert import QualityAlert
 from app.models.cooperative import Cooperative
 from app.models.roaster import Roaster
 
+COFFEE_C_USD_LB_KEY = "COFFEE_C:USD_LB"
+
 
 def detect_score_changes(
     db: Session,
@@ -343,7 +345,7 @@ def detect_price_volatility(
     latest_obs = (
         db.query(MarketObservation)
         .filter(
-            MarketObservation.key == "COFFEE_C:USD_LB",
+            MarketObservation.key == COFFEE_C_USD_LB_KEY,
             MarketObservation.observed_at >= since,
         )
         .order_by(MarketObservation.observed_at.desc())
@@ -354,7 +356,7 @@ def detect_price_volatility(
     oldest_obs = (
         db.query(MarketObservation)
         .filter(
-            MarketObservation.key == "COFFEE_C:USD_LB",
+            MarketObservation.key == COFFEE_C_USD_LB_KEY,
             MarketObservation.observed_at >= since,
         )
         .order_by(MarketObservation.observed_at.asc())
@@ -388,7 +390,7 @@ def detect_price_volatility(
         entity_type="market",
         entity_id=0,
         alert_type="price_volatility",
-        field_name="COFFEE_C:USD_LB",
+        field_name=COFFEE_C_USD_LB_KEY,
         old_value=old_price,
         new_value=new_price,
         change_amount=change_pct,

--- a/apps/api/app/domains/reports/api/routes.py
+++ b/apps/api/app/domains/reports/api/routes.py
@@ -11,7 +11,7 @@ from app.domains.reports.schemas.report import ReportOut
 router = APIRouter()
 DbSessionDep = Annotated[Session, Depends(get_db)]
 ViewerPermissionDep = Annotated[
-    object, Depends(require_role("admin", "analyst", "viewer"))
+    None, Depends(require_role("admin", "analyst", "viewer"))
 ]
 
 
@@ -19,7 +19,7 @@ ViewerPermissionDep = Annotated[
 def list_reports(
     db: DbSessionDep,
     _: ViewerPermissionDep,
-    limit: int = Query(30, ge=1, le=200),
+    limit: Annotated[int, Query(ge=1, le=200)] = 30,
 ):
     return db.query(Report).order_by(Report.report_at.desc()).limit(limit).all()
 


### PR DESCRIPTION
## Summary
- convert remaining FastAPI `Query`/`Path` parameters in flagged routes to `Annotated[...]` style
- replace remaining permission dependency alias typed as `object` in reports routes
- extract `COFFEE_C:USD_LB` into constant in quality alerts service to remove literal duplication

## Validation
- ruff check on touched files
- mypy on touched files
- pytest subset:
  - test_reports_api.py
  - test_news_api.py
  - test_ml_routes_api.py
  - test_ml_predictions_batch.py
  - test_quality_alerts_api.py
  - test_quality_alerts.py
