### PR TITLE
fix: close blocker/critical sonar issues (auth, export, sentiment, schemas)

### DIFF
--- a/apps/api/app/api/deps.py
+++ b/apps/api/app/api/deps.py
@@ -11,6 +11,7 @@ from app.db.session import get_db
 from app.models.user import User
 
 logger = structlog.get_logger(__name__)
+AUTH_FAILED_DETAIL = "Authentifizierung fehlgeschlagen"
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login", auto_error=False)
 
@@ -25,7 +26,7 @@ def _extract_access_token(request: Request, bearer_token: str | None) -> str:
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Authentifizierung fehlgeschlagen",
+        detail=AUTH_FAILED_DETAIL,
         headers={"WWW-Authenticate": "Bearer"},
     )
 
@@ -46,7 +47,7 @@ def get_current_user(
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentifizierung fehlgeschlagen",  # Generic message to prevent info disclosure
+            detail=AUTH_FAILED_DETAIL,  # Generic message to prevent info disclosure
             headers={"WWW-Authenticate": "Bearer"},
         )
     except InvalidTokenError as e:
@@ -57,7 +58,7 @@ def get_current_user(
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentifizierung fehlgeschlagen",  # Generic message to prevent info disclosure
+            detail=AUTH_FAILED_DETAIL,  # Generic message to prevent info disclosure
             headers={"WWW-Authenticate": "Bearer"},
         )
     except HTTPException:
@@ -121,3 +122,5 @@ def require_auth(user: User = Depends(get_current_user)) -> dict:
     a dict instead of User object for endpoints using _: dict = Depends(require_auth).
     """
     return {"user": user, "email": user.email, "role": user.role}
+
+

--- a/apps/api/app/core/export.py
+++ b/apps/api/app/core/export.py
@@ -2,7 +2,7 @@
 
 import csv
 import io
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from fastapi.responses import StreamingResponse
@@ -10,6 +10,12 @@ from fastapi.responses import StreamingResponse
 
 class DataExporter:
     """Export data to various formats."""
+    CREATED_AT_HEADER = "Created At"
+    UPDATED_AT_HEADER = "Updated At"
+
+    @staticmethod
+    def _timestamp_suffix() -> str:
+        return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
 
     @staticmethod
     def to_csv(
@@ -81,14 +87,12 @@ class DataExporter:
                     "Economics Score": coop.economics_score or "",
                     "Total Score": coop.total_score or "",
                     "Confidence": coop.confidence or "",
-                    "Created At": coop.created_at,
-                    "Updated At": coop.updated_at,
+                    DataExporter.CREATED_AT_HEADER: coop.created_at,
+                    DataExporter.UPDATED_AT_HEADER: coop.updated_at,
                 }
             )
 
-        filename = (
-            f"cooperatives_export_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.csv"
-        )
+        filename = f"cooperatives_export_{DataExporter._timestamp_suffix()}.csv"
         return DataExporter.to_csv(data, filename)
 
     @staticmethod
@@ -110,12 +114,12 @@ class DataExporter:
                     "Next Action": roaster.next_action or "",
                     "Total Score": roaster.total_score or "",
                     "Confidence": roaster.confidence or "",
-                    "Created At": roaster.created_at,
-                    "Updated At": roaster.updated_at,
+                    DataExporter.CREATED_AT_HEADER: roaster.created_at,
+                    DataExporter.UPDATED_AT_HEADER: roaster.updated_at,
                 }
             )
 
-        filename = f"roasters_export_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.csv"
+        filename = f"roasters_export_{DataExporter._timestamp_suffix()}.csv"
         return DataExporter.to_csv(data, filename)
 
     @staticmethod
@@ -138,10 +142,10 @@ class DataExporter:
                     "Processing Method": lot.processing_method or "",
                     "Altitude (masl)": lot.altitude_masl or "",
                     "Notes": lot.notes or "",
-                    "Created At": lot.created_at,
-                    "Updated At": lot.updated_at,
+                    DataExporter.CREATED_AT_HEADER: lot.created_at,
+                    DataExporter.UPDATED_AT_HEADER: lot.updated_at,
                 }
             )
 
-        filename = f"lots_export_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.csv"
+        filename = f"lots_export_{DataExporter._timestamp_suffix()}.csv"
         return DataExporter.to_csv(data, filename)

--- a/apps/api/app/domains/sentiment/api/routes.py
+++ b/apps/api/app/domains/sentiment/api/routes.py
@@ -24,9 +24,9 @@ from app.domains.sentiment.services.analysis import (
 router = APIRouter()
 DbSessionDep = Annotated[Session, Depends(get_db)]
 ViewerPermissionDep = Annotated[
-    object, Depends(require_role("admin", "analyst", "viewer"))
+    None, Depends(require_role("admin", "analyst", "viewer"))
 ]
-AnalystPermissionDep = Annotated[object, Depends(require_role("admin", "analyst"))]
+AnalystPermissionDep = Annotated[None, Depends(require_role("admin", "analyst"))]
 
 
 def _require_sentiment_enabled() -> None:
@@ -43,7 +43,7 @@ def sentiment_by_region(
     region: str,
     db: DbSessionDep,
     _: ViewerPermissionDep,
-    limit: int = Query(90, ge=1, le=365),
+    limit: Annotated[int, Query(ge=1, le=365)] = 90,
 ):
     """Return sentiment time series for a region."""
     _require_sentiment_enabled()
@@ -60,7 +60,7 @@ def sentiment_by_entity(
     entity_id: Annotated[int, Path(ge=1)],
     db: DbSessionDep,
     _: ViewerPermissionDep,
-    limit: int = Query(90, ge=1, le=365),
+    limit: Annotated[int, Query(ge=1, le=365)] = 90,
 ):
     """Return sentiment time series for a specific entity."""
     _require_sentiment_enabled()

--- a/apps/api/app/domains/shipments/schemas/shipment.py
+++ b/apps/api/app/domains/shipments/schemas/shipment.py
@@ -152,28 +152,28 @@ class TrackingEventCreate(BaseModel):
 
 class ShipmentOut(BaseModel):
     id: int
-    lot_id: Optional[int]
+    lot_id: Optional[int] = None
     lot_ids: Optional[List[int]] = None
-    cooperative_id: Optional[int]
-    roaster_id: Optional[int]
+    cooperative_id: Optional[int] = None
+    roaster_id: Optional[int] = None
     container_number: str
     bill_of_lading: str
     weight_kg: float
     container_type: str
     origin_port: str
     destination_port: str
-    current_location: Optional[str]
-    departure_date: Optional[str]
-    estimated_arrival: Optional[str]
-    actual_arrival: Optional[str]
+    current_location: Optional[str] = None
+    departure_date: Optional[str] = None
+    estimated_arrival: Optional[str] = None
+    actual_arrival: Optional[str] = None
     departure_at: Optional[datetime] = None
     estimated_arrival_at: Optional[datetime] = None
     actual_arrival_at: Optional[datetime] = None
     status: str
-    status_updated_at: Optional[str]
+    status_updated_at: Optional[str] = None
     delay_hours: int
     tracking_events: Optional[List[TrackingEvent]] = None
-    notes: Optional[str]
+    notes: Optional[str] = None
     deleted_at: Optional[datetime] = None
 
     class Config:

--- a/apps/api/app/domains/sources/api/routes.py
+++ b/apps/api/app/domains/sources/api/routes.py
@@ -15,10 +15,11 @@ from app.core.audit import AuditLogger
 router = APIRouter()
 DbSessionDep = Annotated[Session, Depends(get_db)]
 ViewerPermissionDep = Annotated[
-    object, Depends(require_role("admin", "analyst", "viewer"))
+    None, Depends(require_role("admin", "analyst", "viewer"))
 ]
 AnalystUserDep = Annotated[User, Depends(require_role("admin", "analyst"))]
 AdminUserDep = Annotated[User, Depends(require_role("admin"))]
+NOT_FOUND_DETAIL = "Not found"
 
 
 @router.get("/", response_model=list[SourceOut])
@@ -73,7 +74,7 @@ def get_source(
 ):
     s = db.query(Source).filter(Source.id == source_id).first()
     if not s:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
     return s
 
 
@@ -86,7 +87,7 @@ def update_source(
 ):
     s = db.query(Source).filter(Source.id == source_id).first()
     if not s:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     # Capture old data for audit log
     old_data = {k: getattr(s, k) for k in payload.model_dump(exclude_unset=True).keys()}
@@ -117,7 +118,7 @@ def delete_source(
 ):
     s = db.query(Source).filter(Source.id == source_id).first()
     if not s:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise HTTPException(status_code=404, detail=NOT_FOUND_DETAIL)
 
     # Capture data before deletion for audit log
     entity_data = {

--- a/apps/api/app/middleware/input_validation.py
+++ b/apps/api/app/middleware/input_validation.py
@@ -46,7 +46,9 @@ class InputValidationMiddleware(BaseHTTPMiddleware):
         self.sql_patterns = [
             re.compile(p, re.IGNORECASE) for p in self.SQL_INJECTION_PATTERNS
         ]
-        self.xss_patterns = [re.compile(p, re.IGNORECASE) for p in self.XSS_PATTERNS]
+        self.compiled_xss_patterns = [
+            re.compile(p, re.IGNORECASE) for p in self.XSS_PATTERNS
+        ]
 
     def _check_sql_injection(self, value: str) -> bool:
         """Check if string contains SQL injection patterns."""
@@ -54,7 +56,7 @@ class InputValidationMiddleware(BaseHTTPMiddleware):
 
     def _check_xss(self, value: str) -> bool:
         """Check if string contains XSS patterns."""
-        return any(pattern.search(value) for pattern in self.xss_patterns)
+        return any(pattern.search(value) for pattern in self.compiled_xss_patterns)
 
     def _validate_value(self, value: Any) -> bool:
         """Validate a single value."""


### PR DESCRIPTION
## Summary
- close BLOCKER findings in sentiment DI type hints and middleware XSS field naming
- close multiple CRITICAL findings by:
  - adding explicit defaults for optional shipment output fields
  - deduplicating repeated "Not found" literal in sources routes
  - deduplicating repeated auth failure message constant in deps
  - replacing `datetime.utcnow()` with timezone-aware timestamp helper in exports
  - deduplicating repeated CSV headers via constants

## Validation
- ruff check on touched files
- mypy on touched files
- pytest subset:
  - test_sentiment.py
  - test_shipments.py
  - test_sources_api.py
  - test_auth.py
  - test_export.py
