### PR TITLE
refactor(api): reduce critical complexity in ecb fx and scoring service

### DIFF
--- a/apps/api/app/providers/ecb_fx.py
+++ b/apps/api/app/providers/ecb_fx.py
@@ -22,74 +22,96 @@ class FxQuote:
     raw_text: str
 
 
+def _normalize_currency(value: str) -> str:
+    return value.upper().strip()
+
+
+def _fetch_xml(timeout_s: float) -> Optional[str]:
+    try:
+        response = httpx.get(ECB_DAILY_XML, timeout=timeout_s)
+        response.raise_for_status()
+        return response.text
+    except Exception:
+        return None
+
+
+def _parse_xml(xml_text: str) -> Optional[ET.Element]:
+    try:
+        return ET.fromstring(xml_text)
+    except Exception:
+        return None
+
+
+def _find_time_cube(root: ET.Element) -> Optional[ET.Element]:
+    for node in root.iter():
+        if node.tag.endswith("Cube") and "time" in node.attrib:
+            return node
+    return None
+
+
+def _parse_observed_at(time_value: Optional[str]) -> datetime:
+    if not time_value:
+        return datetime.now(timezone.utc)
+    try:
+        return datetime.fromisoformat(time_value).replace(tzinfo=timezone.utc)
+    except Exception:
+        return datetime.now(timezone.utc)
+
+
+def _extract_rates(time_node: ET.Element) -> dict[str, float]:
+    rates: dict[str, float] = {}
+    for node in time_node:
+        if not node.tag.endswith("Cube"):
+            continue
+        currency = node.attrib.get("currency")
+        rate_value = node.attrib.get("rate")
+        if not currency or not rate_value:
+            continue
+        try:
+            rates[currency.upper()] = float(rate_value)
+        except Exception:
+            continue
+    return rates
+
+
+def _eur_to_rate(currency: str, rates: dict[str, float]) -> Optional[float]:
+    if currency == "EUR":
+        return 1.0
+    return rates.get(currency)
+
+
 def fetch_ecb_fx(base: str, quote: str, timeout_s: float = 20.0) -> Optional[FxQuote]:
     """Fetch FX reference rate from ECB daily XML.
 
     ECB provides rates with base EUR (1 EUR = X QUOTE). If you ask for
     USD->EUR we invert the EUR->USD rate.
     """
-    base = base.upper().strip()
-    quote = quote.upper().strip()
+    base = _normalize_currency(base)
+    quote = _normalize_currency(quote)
     if base == quote:
         return None
 
-    try:
-        r = httpx.get(ECB_DAILY_XML, timeout=timeout_s)
-        r.raise_for_status()
-        xml_text = r.text
-    except Exception:
+    xml_text = _fetch_xml(timeout_s)
+    if xml_text is None:
         return None
 
-    try:
-        root = ET.fromstring(xml_text)
-    except Exception:
+    root = _parse_xml(xml_text)
+    if root is None:
         return None
 
-    # XML uses namespaces; simplest is to search by suffix.
-    time_node = None
-    for n in root.iter():
-        if n.tag.endswith("Cube") and "time" in n.attrib:
-            time_node = n
-            break
+    time_node = _find_time_cube(root)
     if time_node is None:
         return None
 
-    dt_str = time_node.attrib.get("time")
-    if not dt_str:
-        observed_at = datetime.now(timezone.utc)
-    else:
-        try:
-            observed_at = datetime.fromisoformat(dt_str).replace(tzinfo=timezone.utc)
-        except Exception:
-            observed_at = datetime.now(timezone.utc)
+    observed_at = _parse_observed_at(time_node.attrib.get("time"))
+    rates = _extract_rates(time_node)
 
-    # collect rates: quote_ccy -> rate (EUR base)
-    rates: dict[str, float] = {}
-    for n in time_node:
-        if not n.tag.endswith("Cube"):
-            continue
-        ccy = n.attrib.get("currency")
-        rate = n.attrib.get("rate")
-        if not ccy or not rate:
-            continue
-        try:
-            rates[ccy.upper()] = float(rate)
-        except Exception:
-            continue
-
-    # ECB does not include EUR as a currency node; it's the implicit base.
-    def eur_to(ccy: str) -> Optional[float]:
-        if ccy == "EUR":
-            return 1.0
-        return rates.get(ccy)
-
-    eur_to_base = eur_to(base)
-    eur_to_quote = eur_to(quote)
+    eur_to_base = _eur_to_rate(base, rates)
+    eur_to_quote = _eur_to_rate(quote, rates)
     if eur_to_base is None or eur_to_quote is None:
         return None
 
-    # Convert base->quote via EUR: (EUR->quote) / (EUR->base)
-    rate_value: float = eur_to_quote / eur_to_base
+    rate_value = eur_to_quote / eur_to_base
 
     return FxQuote(
         base=base,

--- a/apps/api/app/services/scoring.py
+++ b/apps/api/app/services/scoring.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -45,6 +45,101 @@ def _get_latest_observation(db: Session, key: str) -> Optional[MarketObservation
     )
 
 
+def _compute_quality(coop: Cooperative, meta: dict, reasons: list[str]) -> Optional[float]:
+    if coop.quality_score is not None:
+        reasons.append("Qualitaet: quality_score Feld gesetzt")
+        return _clamp(float(coop.quality_score))
+
+    sca_score = meta.get("sca_score")
+    if isinstance(sca_score, (int, float)):
+        reasons.append("Qualitaet: SCA Score aus meta.sca_score")
+        return _map_sca_to_score(float(sca_score))
+
+    return None
+
+
+def _compute_reliability(coop: Cooperative, meta: dict, reasons: list[str]) -> Optional[float]:
+    if coop.reliability_score is not None:
+        reasons.append("Zuverlaessigkeit: reliability_score Feld gesetzt")
+        return _clamp(float(coop.reliability_score))
+
+    reliability = meta.get("reliability")
+    if isinstance(reliability, (int, float)):
+        reasons.append("Zuverlaessigkeit: meta.reliability")
+        return _clamp(float(reliability))
+
+    return None
+
+
+def _compute_economics(db: Session, coop: Cooperative, meta: dict, reasons: list[str]) -> Optional[float]:
+    if coop.economics_score is not None:
+        reasons.append("Wirtschaftlichkeit: economics_score Feld gesetzt")
+        return _clamp(float(coop.economics_score))
+
+    fob = meta.get("fob_usd_per_kg")
+    if not isinstance(fob, (int, float)):
+        return None
+
+    obs = _get_latest_observation(db, "COFFEE_C:USD_LB")
+    if obs and obs.value > 0:
+        ref_usd_per_kg = float(obs.value) / 0.453592
+        ratio = float(fob) / ref_usd_per_kg
+        reasons.append(
+            f"Wirtschaftlichkeit: FOB vs Referenz (FOB {fob:.2f} USD/kg; Ref ~{ref_usd_per_kg:.2f} USD/kg)"
+        )
+        return _clamp(50.0 + (1.0 - ratio) * 83.0)
+
+    reasons.append("Wirtschaftlichkeit: FOB vorhanden, aber keine COFFEE_C Referenz -> neutral")
+    return 50.0
+
+
+def _compute_confidence(
+    coop: Cooperative,
+    quality: Optional[float],
+    reliability: Optional[float],
+    economics: Optional[float],
+) -> float:
+    signals = 0
+    if quality is not None:
+        signals += 1
+    if reliability is not None:
+        signals += 1
+    if economics is not None:
+        signals += 1
+    if coop.contact_email or coop.website:
+        signals += 1
+    if coop.region or coop.altitude_m is not None:
+        signals += 1
+    return max(0.0, min(1.0, signals / 5))
+
+
+def _compute_total(
+    quality: Optional[float],
+    reliability: Optional[float],
+    economics: Optional[float],
+    confidence: float,
+) -> Optional[float]:
+    if quality is not None and reliability is not None and economics is not None:
+        return _clamp(
+            quality * DEFAULT_WEIGHTS["quality"]
+            + reliability * DEFAULT_WEIGHTS["reliability"]
+            + economics * DEFAULT_WEIGHTS["economics"]
+        )
+
+    dims: list[Tuple[str, Optional[float]]] = [
+        ("quality", quality),
+        ("reliability", reliability),
+        ("economics", economics),
+    ]
+    present = [(key, value) for (key, value) in dims if value is not None]
+    if not present:
+        return None
+
+    weight_sum = sum(DEFAULT_WEIGHTS[key] for key, _ in present)
+    base = sum(value * DEFAULT_WEIGHTS[key] for key, value in present) / weight_sum
+    return _clamp(base * (0.5 + 0.5 * confidence))
+
+
 def compute_cooperative_score(db: Session, coop: Cooperative) -> ScoreBreakdown:
     """Compute score using available hard fields + optional meta hints.
 
@@ -54,97 +149,19 @@ def compute_cooperative_score(db: Session, coop: Cooperative) -> ScoreBreakdown:
     """
 
     reasons: list[str] = []
-
-    # --- Quality ---
-    q = None
     meta = coop.meta or {}
-    if coop.quality_score is not None:
-        q = _clamp(float(coop.quality_score))
-        reasons.append("Qualität: quality_score Feld gesetzt")
-    elif isinstance(meta.get("sca_score"), (int, float)):
-        q = _map_sca_to_score(float(meta["sca_score"]))
-        reasons.append("Qualität: SCA Score aus meta.sca_score")
 
-    # --- Reliability ---
-    r = None
-    if coop.reliability_score is not None:
-        r = _clamp(float(coop.reliability_score))
-        reasons.append("Zuverlässigkeit: reliability_score Feld gesetzt")
-    elif isinstance(meta.get("reliability"), (int, float)):
-        r = _clamp(float(meta["reliability"]))
-        reasons.append("Zuverlässigkeit: meta.reliability")
+    quality = _compute_quality(coop, meta, reasons)
+    reliability = _compute_reliability(coop, meta, reasons)
+    economics = _compute_economics(db, coop, meta, reasons)
 
-    # --- Economics ---
-    e = None
-    if coop.economics_score is not None:
-        e = _clamp(float(coop.economics_score))
-        reasons.append("Wirtschaftlichkeit: economics_score Feld gesetzt")
-    else:
-        fob = meta.get("fob_usd_per_kg")
-        if isinstance(fob, (int, float)):
-            # Use coffee 'C' as a crude proxy: COFFEE_C:USD_LB => convert to USD/kg (1 lb=0.453592)
-            obs = _get_latest_observation(db, "COFFEE_C:USD_LB")
-            if obs and obs.value > 0:
-                ref_usd_per_kg = float(obs.value) / 0.453592
-                # cheaper than reference improves score; more expensive reduces.
-                # ratio 0.7 => +25; ratio 1.3 => -25
-                ratio = float(fob) / ref_usd_per_kg
-                e = _clamp(50.0 + (1.0 - ratio) * 83.0)
-                reasons.append(
-                    f"Wirtschaftlichkeit: FOB vs Referenz (FOB {fob:.2f} USD/kg; Ref ~{ref_usd_per_kg:.2f} USD/kg)"
-                )
-            else:
-                # without reference, we stay conservative-neutral
-                e = 50.0
-                reasons.append(
-                    "Wirtschaftlichkeit: FOB vorhanden, aber keine COFFEE_C Referenz -> neutral"
-                )
-
-    # --- Confidence ---
-    # Hard signals:
-    #  - quality, reliability, economics
-    #  - contact channel (email or website)
-    #  - region/altitude metadata
-    signals = 0
-    possible = 5
-    if q is not None:
-        signals += 1
-    if r is not None:
-        signals += 1
-    if e is not None:
-        signals += 1
-    if coop.contact_email or coop.website:
-        signals += 1
-    if coop.region or coop.altitude_m is not None:
-        signals += 1
-
-    confidence = max(0.0, min(1.0, signals / possible))
-
-    # --- Total ---
-    total = None
-    if q is not None and r is not None and e is not None:
-        total = _clamp(
-            q * DEFAULT_WEIGHTS["quality"]
-            + r * DEFAULT_WEIGHTS["reliability"]
-            + e * DEFAULT_WEIGHTS["economics"]
-        )
-    else:
-        # If incomplete: compute using available dimensions but down-weight via confidence
-        dims: list[Tuple[str, Optional[float]]] = [
-            ("quality", q),
-            ("reliability", r),
-            ("economics", e),
-        ]
-        present = [(k, v) for (k, v) in dims if v is not None]
-        if present:
-            w_sum = sum(DEFAULT_WEIGHTS[k] for k, _ in present)
-            base = sum(v * DEFAULT_WEIGHTS[k] for k, v in present) / w_sum
-            total = _clamp(base * (0.5 + 0.5 * confidence))
+    confidence = _compute_confidence(coop, quality, reliability, economics)
+    total = _compute_total(quality, reliability, economics, confidence)
 
     return ScoreBreakdown(
-        quality=q,
-        reliability=r,
-        economics=e,
+        quality=quality,
+        reliability=reliability,
+        economics=economics,
         total=total,
         confidence=confidence,
         reasons=reasons,


### PR DESCRIPTION
## Summary\n- refactor etch_ecb_fx into focused helper functions to lower cognitive complexity\n- refactor cooperative scoring flow into small composable helpers\n- preserve behavior and API while improving maintainability\n\n## Validation\n- cd apps/api && ruff check app/providers/ecb_fx.py app/services/scoring.py\n- cd apps/api && mypy app/providers/ecb_fx.py app/services/scoring.py\n- cd apps/api && pytest -q tests/test_ecb_fx_provider.py tests/test_fx_rates_provider.py tests/test_scoring_service.py tests/test_cooperatives.py