### PR TITLE
refactor(api): reduce complexity in validation middleware and report builder

### DIFF
--- a/apps/api/app/domains/reports/services/report_builder.py
+++ b/apps/api/app/domains/reports/services/report_builder.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -6,51 +6,43 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy.orm import Session
 
 from app.models.cooperative import Cooperative
-from app.models.roaster import Roaster
 from app.models.market import MarketObservation
+from app.models.roaster import Roaster
+
+
+MARKET_KEYS = [
+    "FX:USD_EUR",
+    "COFFEE_C:USD_LB",
+    "FREIGHT:USD_PER_40FT",
+]
 
 
 def _latest_by_key(
     db: Session, keys: List[str]
 ) -> Dict[str, Optional[MarketObservation]]:
     out: Dict[str, Optional[MarketObservation]] = {}
-    for k in keys:
-        out[k] = (
+    for key in keys:
+        out[key] = (
             db.query(MarketObservation)
-            .filter(MarketObservation.key == k)
+            .filter(MarketObservation.key == key)
             .order_by(MarketObservation.observed_at.desc())
             .first()
         )
     return out
 
 
-def _fmt_obs(o: Optional[MarketObservation]) -> str:
-    if not o:
+def _fmt_obs(observation: Optional[MarketObservation]) -> str:
+    if not observation:
         return "-"
-    val = f"{o.value:g}"
-    unit = f" {o.unit}" if o.unit else ""
-    cur = f" {o.currency}" if o.currency else ""
-    ts = o.observed_at.astimezone(timezone.utc).isoformat()
-    return f"{val}{unit}{cur} (t={ts})"
+    value = f"{observation.value:g}"
+    unit = f" {observation.unit}" if observation.unit else ""
+    currency = f" {observation.currency}" if observation.currency else ""
+    timestamp = observation.observed_at.astimezone(timezone.utc).isoformat()
+    return f"{value}{unit}{currency} (t={timestamp})"
 
 
-def generate_daily_report(db: Session) -> tuple[str, Dict]:
-    """Generate a compact daily report (markdown + structured payload).
-
-    This intentionally keeps assumptions conservative and highlights missing data.
-    """
-    now = datetime.now(timezone.utc)
-
-    # Market keys we care about early on
-    market_keys = [
-        "FX:USD_EUR",
-        "COFFEE_C:USD_LB",
-        "FREIGHT:USD_PER_40FT",
-    ]
-    latest = _latest_by_key(db, market_keys)
-
-    # Top coops
-    coops = (
+def _get_top_coops(db: Session) -> List[Cooperative]:
+    return (
         db.query(Cooperative)
         .filter(Cooperative.status != "archived")
         .order_by(
@@ -62,8 +54,9 @@ def generate_daily_report(db: Session) -> tuple[str, Dict]:
         .all()
     )
 
-    # Roasters snapshot
-    roasters = (
+
+def _get_roasters_snapshot(db: Session) -> List[Roaster]:
+    return (
         db.query(Roaster)
         .filter(Roaster.status != "archived")
         .order_by(
@@ -75,106 +68,131 @@ def generate_daily_report(db: Session) -> tuple[str, Dict]:
         .all()
     )
 
-    md_lines: List[str] = []
-    md_lines.append(f"# CoffeeStudio Tagesreport (UTC) - {now.date().isoformat()}")
-    md_lines.append("")
 
-    # Market
-    md_lines.append("## Markt & Preise")
-    md_lines.append(f"- USD->EUR: {_fmt_obs(latest.get('FX:USD_EUR'))}")
-    md_lines.append(f"- Coffee C (USD/lb): {_fmt_obs(latest.get('COFFEE_C:USD_LB'))}")
-    md_lines.append(
-        f"- Fracht 40ft (USD): {_fmt_obs(latest.get('FREIGHT:USD_PER_40FT'))}"
-    )
-    md_lines.append("")
+def _append_market_section(lines: List[str], latest: Dict[str, Optional[MarketObservation]]) -> None:
+    lines.append("## Markt & Preise")
+    lines.append(f"- USD->EUR: {_fmt_obs(latest.get('FX:USD_EUR'))}")
+    lines.append(f"- Coffee C (USD/lb): {_fmt_obs(latest.get('COFFEE_C:USD_LB'))}")
+    lines.append(f"- Fracht 40ft (USD): {_fmt_obs(latest.get('FREIGHT:USD_PER_40FT'))}")
+    lines.append("")
 
-    # Coops
-    md_lines.append("## Kooperativen Peru - Top 10")
+
+def _append_coops_section(lines: List[str], coops: List[Cooperative]) -> None:
+    lines.append("## Kooperativen Peru - Top 10")
     if not coops:
-        md_lines.append("- (keine Eintraege)")
-    else:
-        for c in coops:
-            score = f"{c.total_score:.1f}" if c.total_score is not None else "-"
-            conf = f"{c.confidence:.2f}" if c.confidence is not None else "-"
-            md_lines.append(
-                f"- **{c.name}** ({c.region or 'Region n/a'}) - Score: {score}, Confidence: {conf}"
-            )
-            if c.next_action:
-                md_lines.append(f"  - Next Action: {c.next_action}")
-            if c.requested_data:
-                md_lines.append(
-                    "  - Offene Daten: "
-                    + (
-                        c.requested_data[:140] + "..."
-                        if len(c.requested_data) > 140
-                        else c.requested_data
-                    )
-                )
-    md_lines.append("")
+        lines.append("- (keine Eintraege)")
+        lines.append("")
+        return
 
-    # Roasters
-    md_lines.append("## Roester Deutschland - Auszug")
+    for coop in coops:
+        score = f"{coop.total_score:.1f}" if coop.total_score is not None else "-"
+        confidence = f"{coop.confidence:.2f}" if coop.confidence is not None else "-"
+        lines.append(
+            f"- **{coop.name}** ({coop.region or 'Region n/a'}) - Score: {score}, Confidence: {confidence}"
+        )
+        if coop.next_action:
+            lines.append(f"  - Next Action: {coop.next_action}")
+        if coop.requested_data:
+            requested_data = coop.requested_data
+            if len(requested_data) > 140:
+                requested_data = requested_data[:140] + "..."
+            lines.append(f"  - Offene Daten: {requested_data}")
+    lines.append("")
+
+
+def _append_roasters_section(lines: List[str], roasters: List[Roaster]) -> None:
+    lines.append("## Roester Deutschland - Auszug")
     if not roasters:
-        md_lines.append("- (keine Eintraege)")
-    else:
-        for r in roasters:
-            flags = []
-            if r.peru_focus:
-                flags.append("Peru")
-            if r.specialty_focus:
-                flags.append("Specialty")
-            f = f" [{', '.join(flags)}]" if flags else ""
-            md_lines.append(f"- **{r.name}** ({r.city or 'n/a'}){f}")
+        lines.append("- (keine Eintraege)")
+        lines.append("")
+        return
 
-    md_lines.append("")
+    for roaster in roasters:
+        flags = []
+        if roaster.peru_focus:
+            flags.append("Peru")
+        if roaster.specialty_focus:
+            flags.append("Specialty")
+        suffix = f" [{', '.join(flags)}]" if flags else ""
+        lines.append(f"- **{roaster.name}** ({roaster.city or 'n/a'}){suffix}")
+    lines.append("")
 
-    # Actions (very conservative default)
-    md_lines.append("## Empfohlene Aktionen")
-    md_lines.append(
+
+def _append_actions_section(lines: List[str]) -> None:
+    lines.append("## Empfohlene Aktionen")
+    lines.append(
         "- 1) Fehlende Marktdaten ergaenzen (FX/C-Preis/Fracht) -> verbessert Margenberechnungen"
     )
-    md_lines.append(
-        "- 2) Top-3 Kooperativen: Kontaktdaten verifizieren + Muster/Lots anfragen"
-    )
-    md_lines.append(
+    lines.append("- 2) Top-3 Kooperativen: Kontaktdaten verifizieren + Muster/Lots anfragen")
+    lines.append(
         "- 3) 3-5 passende Roester identifizieren und Gespraech anbahnen (Peru-/Direct-Trade-Fokus)"
     )
 
-    # Build market dict with proper null checks
-    market_dict: Dict[str, Optional[Dict[str, Any]]] = {}
-    for k in market_keys:
-        obs = latest.get(k)
-        if obs is not None:
-            market_dict[k] = {
-                "value": obs.value,
-                "observed_at": obs.observed_at.isoformat(),
-            }
-        else:
-            market_dict[k] = None
 
-    payload: Dict = {
+def _build_market_payload(
+    latest: Dict[str, Optional[MarketObservation]], keys: List[str]
+) -> Dict[str, Optional[Dict[str, Any]]]:
+    market_payload: Dict[str, Optional[Dict[str, Any]]] = {}
+    for key in keys:
+        observation = latest.get(key)
+        if observation is None:
+            market_payload[key] = None
+            continue
+        market_payload[key] = {
+            "value": observation.value,
+            "observed_at": observation.observed_at.isoformat(),
+        }
+    return market_payload
+
+
+def _build_payload(
+    now: datetime,
+    latest: Dict[str, Optional[MarketObservation]],
+    coops: List[Cooperative],
+    roasters: List[Roaster],
+) -> Dict[str, Any]:
+    return {
         "generated_at": now.isoformat(),
-        "market": market_dict,
+        "market": _build_market_payload(latest, MARKET_KEYS),
         "top_coops": [
             {
-                "id": c.id,
-                "name": c.name,
-                "region": c.region,
-                "score": c.total_score,
-                "confidence": c.confidence,
+                "id": coop.id,
+                "name": coop.name,
+                "region": coop.region,
+                "score": coop.total_score,
+                "confidence": coop.confidence,
             }
-            for c in coops
+            for coop in coops
         ],
         "roasters": [
             {
-                "id": r.id,
-                "name": r.name,
-                "city": r.city,
-                "peru_focus": r.peru_focus,
-                "specialty_focus": r.specialty_focus,
+                "id": roaster.id,
+                "name": roaster.name,
+                "city": roaster.city,
+                "peru_focus": roaster.peru_focus,
+                "specialty_focus": roaster.specialty_focus,
             }
-            for r in roasters
+            for roaster in roasters
         ],
     }
 
-    return "\n".join(md_lines), payload
+
+def generate_daily_report(db: Session) -> tuple[str, Dict[str, Any]]:
+    """Generate a compact daily report (markdown + structured payload)."""
+    now = datetime.now(timezone.utc)
+    latest = _latest_by_key(db, MARKET_KEYS)
+    coops = _get_top_coops(db)
+    roasters = _get_roasters_snapshot(db)
+
+    markdown_lines: List[str] = [
+        f"# CoffeeStudio Tagesreport (UTC) - {now.date().isoformat()}",
+        "",
+    ]
+
+    _append_market_section(markdown_lines, latest)
+    _append_coops_section(markdown_lines, coops)
+    _append_roasters_section(markdown_lines, roasters)
+    _append_actions_section(markdown_lines)
+
+    payload = _build_payload(now, latest, coops, roasters)
+    return "\n".join(markdown_lines), payload

--- a/apps/api/app/middleware/input_validation.py
+++ b/apps/api/app/middleware/input_validation.py
@@ -1,8 +1,9 @@
 """Input validation middleware for request sanitization."""
 
+import json
 import re
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -78,66 +79,85 @@ class InputValidationMiddleware(BaseHTTPMiddleware):
                 return False
         return True
 
+    @staticmethod
+    def _client_host(request: Request) -> str:
+        return request.client.host if request.client else "unknown"
+
+    @staticmethod
+    def _is_write_method(request: Request) -> bool:
+        return request.method in {"POST", "PUT", "PATCH"}
+
+    @staticmethod
+    def _is_json_request(request: Request) -> bool:
+        return "application/json" in request.headers.get("content-type", "")
+
+    @staticmethod
+    def _parse_content_length(request: Request) -> Optional[int]:
+        content_length = request.headers.get("content-length")
+        if not content_length:
+            return None
+        return int(content_length)
+
+    @staticmethod
+    def _payload_too_large_response(content_size: int, host: str) -> Response:
+        logger.warning(f"Request body too large: {content_size} bytes from {host}")
+        from app.core.error_handlers import ErrorResponse
+
+        return ErrorResponse.format_error(
+            error_code="REQUEST_TOO_LARGE",
+            message=f"Request body too large. Maximum size is {MAX_REQUEST_BODY_SIZE} bytes.",
+            status_code=413,
+        )
+
+    @staticmethod
+    def _malicious_input_response(host: str, path: str) -> Response:
+        logger.warning(f"Malicious input detected from {host} to {path}")
+        from app.core.error_handlers import ErrorResponse
+
+        return ErrorResponse.format_error(
+            error_code="MALICIOUS_INPUT",
+            message="Invalid input detected. Request contains potentially malicious content.",
+            status_code=400,
+            detail=[{"msg": "Invalid characters in request body"}],
+        )
+
+    async def _validate_json_body(self, request: Request) -> Optional[Response]:
+        host = self._client_host(request)
+        body_bytes = await request.body()
+
+        if len(body_bytes) > MAX_REQUEST_BODY_SIZE:
+            return self._payload_too_large_response(len(body_bytes), host)
+
+        if not body_bytes:
+            return None
+
+        try:
+            body = json.loads(body_bytes)
+        except Exception:
+            # If JSON parsing fails, let FastAPI handle it.
+            return None
+
+        if isinstance(body, dict) and not self._validate_dict(body):
+            return self._malicious_input_response(host, request.url.path)
+        return None
+
     async def dispatch(self, request: Request, call_next: Any) -> Response:
         """Validate request data."""
-        # Skip validation for GET requests (query params handled by FastAPI)
-        if request.method in ["POST", "PUT", "PATCH"]:
-            try:
-                # Check Content-Length header for body size limit
-                content_length = request.headers.get("content-length")
-                if content_length and int(content_length) > MAX_REQUEST_BODY_SIZE:
-                    logger.warning(
-                        f"Request body too large: {content_length} bytes from {request.client.host if request.client else 'unknown'}"
-                    )
-                    from app.core.error_handlers import ErrorResponse
+        if not self._is_write_method(request):
+            return await call_next(request)
 
-                    return ErrorResponse.format_error(
-                        error_code="REQUEST_TOO_LARGE",
-                        message=f"Request body too large. Maximum size is {MAX_REQUEST_BODY_SIZE} bytes.",
-                        status_code=413,
-                    )
+        try:
+            host = self._client_host(request)
+            content_length = self._parse_content_length(request)
+            if content_length and content_length > MAX_REQUEST_BODY_SIZE:
+                return self._payload_too_large_response(content_length, host)
 
-                if "application/json" in request.headers.get("content-type", ""):
-                    # Read the body as bytes to avoid consuming the stream
-                    body_bytes = await request.body()
+            if self._is_json_request(request):
+                validation_response = await self._validate_json_body(request)
+                if validation_response is not None:
+                    return validation_response
+        except Exception:
+            # If we can't read or validate safely, let FastAPI handle the request.
+            pass
 
-                    # Double-check actual body size
-                    if len(body_bytes) > MAX_REQUEST_BODY_SIZE:
-                        logger.warning(
-                            f"Request body too large: {len(body_bytes)} bytes from {request.client.host if request.client else 'unknown'}"
-                        )
-                        from app.core.error_handlers import ErrorResponse
-
-                        return ErrorResponse.format_error(
-                            error_code="REQUEST_TOO_LARGE",
-                            message=f"Request body too large. Maximum size is {MAX_REQUEST_BODY_SIZE} bytes.",
-                            status_code=413,
-                        )
-
-                    if body_bytes:
-                        try:
-                            body = __import__("json").loads(body_bytes)
-                            if not self._validate_dict(body):
-                                logger.warning(
-                                    f"Malicious input detected from {request.client.host if request.client else 'unknown'} "
-                                    f"to {request.url.path}"
-                                )
-                                from app.core.error_handlers import ErrorResponse
-
-                                return ErrorResponse.format_error(
-                                    error_code="MALICIOUS_INPUT",
-                                    message="Invalid input detected. Request contains potentially malicious content.",
-                                    status_code=400,
-                                    detail=[
-                                        {"msg": "Invalid characters in request body"}
-                                    ],
-                                )
-                        except Exception:
-                            # If JSON parsing fails, let FastAPI handle it
-                            pass
-            except Exception:
-                # If we can't read the body, let FastAPI handle it
-                pass
-
-        response: Response = await call_next(request)
-        return response
+        return await call_next(request)


### PR DESCRIPTION
## Summary
- split InputValidationMiddleware.dispatch into focused validation helpers
- extract report-generation sections and payload builders from generate_daily_report
- keep existing behavior and output structure while reducing complexity

## Validation
- cd apps/api && ruff check app/middleware/input_validation.py app/domains/reports/services/report_builder.py
- cd apps/api && mypy app/middleware/input_validation.py app/domains/reports/services/report_builder.py
- cd apps/api && pytest -q tests/test_input_validation.py tests/test_middleware.py tests/test_reports_service.py tests/test_reports_api.py