### PR TITLE
chore: add repeatable repo and docker cleanup workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ PYTHON ?= python3
 ENTERPRISE_COMPOSE ?= infra/deploy/docker-compose.enterprise.yml
 
 .PHONY: help up up-full down logs status migrate bootstrap smoke smoke-win \
-        start-enterprise stop-enterprise enterprise-logs enterprise-status enterprise-restart
+        start-enterprise stop-enterprise enterprise-logs enterprise-status enterprise-restart \
+        cleanup-local cleanup-local-apply cleanup-local-docker
 
 help:
 	@echo "CoffeeStudio Platform — common targets"
@@ -78,3 +79,15 @@ enterprise-status:
 enterprise-restart:
 	$(MAKE) stop-enterprise
 	$(MAKE) start-enterprise
+
+# -----------------------
+# Local hygiene / cleanup
+# -----------------------
+cleanup-local:
+	powershell -ExecutionPolicy Bypass -File scripts/maintenance/cleanup_local_artifacts.ps1
+
+cleanup-local-apply:
+	powershell -ExecutionPolicy Bypass -File scripts/maintenance/cleanup_local_artifacts.ps1 -Apply
+
+cleanup-local-docker:
+	powershell -ExecutionPolicy Bypass -File scripts/maintenance/cleanup_local_artifacts.ps1 -Apply -DockerPrune

--- a/docs/operations/backend-setup.md
+++ b/docs/operations/backend-setup.md
@@ -93,6 +93,29 @@ Migration failures:
 3. If local state is broken, recreate local volumes only when appropriate:
    `docker compose down -v && docker compose up -d --build`
 
+## Repo and Docker Cleanup
+
+Use the maintenance script for repeatable local cleanup:
+
+```powershell
+# show what would be removed
+powershell -ExecutionPolicy Bypass -File scripts/maintenance/cleanup_local_artifacts.ps1
+
+# apply local repo artifact cleanup
+powershell -ExecutionPolicy Bypass -File scripts/maintenance/cleanup_local_artifacts.ps1 -Apply
+
+# apply cleanup including Docker image/cache prune
+powershell -ExecutionPolicy Bypass -File scripts/maintenance/cleanup_local_artifacts.ps1 -Apply -DockerPrune
+```
+
+Equivalent `make` targets:
+
+```bash
+make cleanup-local
+make cleanup-local-apply
+make cleanup-local-docker
+```
+
 ## Related Docs
 
 - `README.md`

--- a/scripts/maintenance/cleanup_local_artifacts.ps1
+++ b/scripts/maintenance/cleanup_local_artifacts.ps1
@@ -1,0 +1,81 @@
+param(
+    [switch]$Apply,
+    [switch]$DockerPrune
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+Set-Location $repoRoot
+
+$pathsToClean = @(
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "apps/api/.mypy_cache",
+    "apps/api/.ruff_cache",
+    "apps/web/logs",
+    "apps/api/.qa_reports"
+)
+
+$filePatterns = @(
+    "*.log",
+    "*.sarif",
+    "bandit-report.json",
+    "trivy-*-results.sarif"
+)
+
+Write-Host "== CoffeeStudio Local Cleanup =="
+Write-Host "Repo: $repoRoot"
+Write-Host "Mode: $([string]::Join('', @($(if ($Apply) {'APPLY'} else {'DRY-RUN'}), $(if ($DockerPrune) {' + DOCKER-PRUNE'} else {''}))))"
+
+foreach ($target in $pathsToClean) {
+    if (Test-Path $target) {
+        if ($Apply) {
+            Remove-Item -Recurse -Force $target
+            Write-Host "[deleted dir] $target"
+        } else {
+            Write-Host "[would delete dir] $target"
+        }
+    }
+}
+
+foreach ($pattern in $filePatterns) {
+    $hits = Get-ChildItem -Path . -Recurse -File -Filter $pattern -ErrorAction SilentlyContinue
+    foreach ($hit in $hits) {
+        $rel = Resolve-Path -Relative $hit.FullName
+        if ($Apply) {
+            Remove-Item -Force $hit.FullName
+            Write-Host "[deleted file] $rel"
+        } else {
+            Write-Host "[would delete file] $rel"
+        }
+    }
+}
+
+if ($DockerPrune) {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        Write-Warning "Docker CLI not found. Skipping docker prune."
+        exit 0
+    }
+
+    Write-Host "`n== Docker Usage (before) =="
+    docker system df
+
+    if ($Apply) {
+        Write-Host "`nRunning docker image prune -af ..."
+        docker image prune -af
+        Write-Host "`nRunning docker system prune -af ..."
+        docker system prune -af
+    } else {
+        Write-Host "`n[dry-run] Docker prune would run:"
+        Write-Host "  docker image prune -af"
+        Write-Host "  docker system prune -af"
+    }
+
+    Write-Host "`n== Docker Usage (after) =="
+    docker system df
+}
+
+Write-Host "`nCleanup finished."


### PR DESCRIPTION
Summary:
- add scripts/maintenance/cleanup_local_artifacts.ps1 with dry-run by default
- add make targets: cleanup-local, cleanup-local-apply, cleanup-local-docker
- document cleanup flow in backend setup docs

Validation:
- executed script in dry-run mode successfully
- performed Docker hygiene pass and verified reclaimed cache/image space
